### PR TITLE
Edgeタッチ端末で戻り時間選択が反映されない問題を修正

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -483,7 +483,13 @@ function wireEvents(){
   board.addEventListener('compositionstart', e => { const t=e.target; if(t && t.dataset) t.dataset.composing='1'; });
   board.addEventListener('compositionend',   e => { const t=e.target; if(t && t.dataset) delete t.dataset.composing; });
 
-  board.addEventListener('focusin',  e => { const t=e.target; if(t && t.dataset) t.dataset.editing='1'; });
+  board.addEventListener('focusin',  e => {
+    const t=e.target;
+    if(t && t.dataset) t.dataset.editing='1';
+    if(t && (t.name === 'status' || t.name === 'time')){
+      t.dataset.prevValue = t.value;
+    }
+  });
   board.addEventListener('focusout', e =>{
     const t=e.target;
     if(!(t && t.dataset)) return;
@@ -491,6 +497,13 @@ function wireEvents(){
     const key=tr?.dataset.key;
     if((t.name==='note' || t.name==='workHours') && key && PENDING_ROWS.has(key)){ t.dataset.editing='1'; }
     else{ delete t.dataset.editing; }
+    if(t.name === 'status' || t.name === 'time'){
+      const prev = t.dataset.prevValue;
+      if(prev !== undefined && prev !== t.value){
+        handleStatusTimeChange({ target: t });
+      }
+      delete t.dataset.prevValue;
+    }
   });
   // 入力（備考：入力中は自動更新停止 → setIfNeeded が弾く）
   board.addEventListener('input', (e)=>{
@@ -508,6 +521,10 @@ function wireEvents(){
     if(!t) return;
     const tr = t.closest('tr'); if(!tr) return;
     const key = tr.dataset.key;
+
+    if(t.dataset){
+      t.dataset.prevValue = t.value;
+    }
 
     if(t.name === 'status'){
       t.dataset.editing = '1';


### PR DESCRIPTION
## Summary
- フォーカスイン時にステータス・戻り時間の直前値を記録し、変更検知の安定性を向上
- フォーカスアウト時に値の差分を検出してハンドラーを明示的に呼び出し、Edgeタッチ操作でも戻り時間が確実に反映されるように調整
- 変更処理側で最新値を保存し、重複検出や誤判定を防止

## Testing
- 未実施（自動テストなし）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca3b681c88327b69b5b4a3b2f566b)