### PR TITLE
ステータス／時間入力のデバッグログ追加

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -211,6 +211,7 @@ function buildCandidateField({ id, name, placeholder, type, value }){
 }
 
 let candidatePanelGlobalsBound = false;
+let lastInteractionWasTouch = false;
 function bindCandidatePanelGlobals(){
   if(candidatePanelGlobalsBound) return;
   candidatePanelGlobalsBound = true;
@@ -414,6 +415,10 @@ function applyState(data){
     const localRev  = Number(tr?.dataset.rev || 0);
     if(tr && remoteRev > localRev){ tr.dataset.rev = String(remoteRev); tr.dataset.serverUpdated = String(v.serverUpdated || 0); }
 
+    if(lastInteractionWasTouch){
+      const hasPending = PENDING_ROWS.has(k);
+      console.log('[touch applyState]', { key: k, pending: hasPending, statusValue: s?.value, timeValue: t?.value });
+    }
     ensureTimePrompt(tr);
   });
   recolor();
@@ -516,11 +521,28 @@ function wireEvents(){
   });
 
   // 変更（ステータス/時間）
+  const logStatusTimeEvent = (event)=>{
+    const target = event.target;
+    if(!(target && (target.name === 'status' || target.name === 'time'))) return;
+    if(event.type.startsWith('touch')){
+      lastInteractionWasTouch = true;
+    }else if(event.type.startsWith('pointer')){
+      lastInteractionWasTouch = event.pointerType === 'touch';
+    }
+    console.log('[status/time event]', {
+      name: target.name,
+      value: target.value,
+      disabled: target.disabled,
+      type: event.type
+    });
+  };
+
   const handleStatusTimeChange = (e)=>{
     const t = e.target;
     if(!t) return;
     const tr = t.closest('tr'); if(!tr) return;
     const key = tr.dataset.key;
+    const prevVal = t.dataset?.prevValue;
 
     if(t.dataset){
       t.dataset.prevValue = t.value;
@@ -530,7 +552,9 @@ function wireEvents(){
       t.dataset.editing = '1';
       const timeSel = tr.querySelector('select[name="time"]');
       const noteInp = tr.querySelector('input[name="note"]');
+      console.log('[status change] before toggle', { key, prev: prevVal, next: t.value, timeDisabled: timeSel?.disabled });
       toggleTimeEnable(t, timeSel);
+      console.log('[status change] time disabled after toggle', { key, status: t.value, timeDisabled: timeSel?.disabled });
 
       if(clearOnSet.has(t.value)){
         if(timeSel) timeSel.value = '';
@@ -546,11 +570,19 @@ function wireEvents(){
 
     if(t.name === 'time'){
       t.dataset.editing = '1';
+      console.log('[time change]', { key, prev: prevVal, next: t.value });
       ensureTimePrompt(tr);
       debounceRowPush(key);
       return;
     }
   };
+
+  ['pointerdown','pointerup','touchstart','touchend','touchcancel','click','input','change'].forEach(type=>{
+    board.addEventListener(type, logStatusTimeEvent, true);
+  });
+  ['focus','blur'].forEach(type=>{
+    board.addEventListener(type, logStatusTimeEvent, true);
+  });
 
   board.addEventListener('change', handleStatusTimeChange);
   // Edge（特にタッチ操作）で change イベントが拾えないケースへのフォールバック


### PR DESCRIPTION
## Summary
- ステータス・時間入力イベントログに前後の値や状態を追加し、再現時の差分を把握できるようにしました
- ステータス変更時の time 要素 disabled 状態の前後を記録
- タッチ適用時の applyState ログにステータス値を含めて状態復元可否を確認しやすくしました

## Testing
- 未実行


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cc2b332a88327bcf12365f8b6d04d)