### PR TITLE
fix: ログアウト時に保留行送信をリセット

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -15,6 +15,7 @@ async function logout(){
     if(configWatchTimer){ clearInterval(configWatchTimer); configWatchTimer=null; }
     if(remotePullTimer){ clearInterval(remotePullTimer); remotePullTimer=null; }
     if(eventSyncTimer){ clearInterval(eventSyncTimer); eventSyncTimer=null; }
+    if(typeof clearPendingRows==='function'){ clearPendingRows(); }
     if(ro){ try{ ro.disconnect(); }catch{} }
     stopNoticesPolling();
   }catch{}

--- a/js/board.js
+++ b/js/board.js
@@ -456,6 +456,14 @@ function loadLocal(){ try{ const raw=localStorage.getItem(localKey()); if(raw) a
 const rowTimers=new Map();
 function debounceRowPush(key,delay=900){ PENDING_ROWS.add(key); if(rowTimers.has(key)) clearTimeout(rowTimers.get(key)); rowTimers.set(key,setTimeout(()=>{ rowTimers.delete(key); pushRowDelta(key); },delay)); }
 
+function clearPendingRows(){
+  rowTimers.forEach(timerId=>{
+    try{ clearTimeout(timerId); }catch{}
+  });
+  rowTimers.clear();
+  PENDING_ROWS.clear();
+}
+
 /* 入力イベント（IME配慮・デバウンス） */
 function wireEvents(){
   bindCandidatePanelGlobals();


### PR DESCRIPTION
## 概要
- 行送信のデバウンスタイマーと保留セットをまとめてクリアする clearPendingRows を追加
- ログアウト処理で clearPendingRows を呼び出し、セッション終了後の送信や編集中扱いの残留を防止

## テスト
- 未実施（自動テストなし）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ccd09dabc8327a8e6f5bc4d917f5f)