### PR TITLE
time セレクトのフォールバックイベント追加

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -585,6 +585,23 @@ function wireEvents(){
     }
   };
 
+  const forceCommitTimeSelection = (event)=>{
+    const timeEl = event.target;
+    if(!(timeEl && timeEl.name === 'time')) return;
+    if(timeEl.dataset?.editing === '1' && timeEl !== document.activeElement) return;
+
+    const selectedOption = timeEl.options?.[timeEl.selectedIndex];
+    if(!selectedOption) return;
+
+    const selectedValue = selectedOption.value;
+    if(timeEl.value !== selectedValue){
+      timeEl.value = selectedValue;
+    }
+
+    timeEl.dispatchEvent(new Event('input', { bubbles: true }));
+    timeEl.dispatchEvent(new Event('change', { bubbles: true }));
+  };
+
   ['pointerdown','pointerup','touchstart','touchend','touchcancel','click','input','change'].forEach(type=>{
     board.addEventListener(type, logStatusTimeEvent, true);
   });
@@ -593,6 +610,8 @@ function wireEvents(){
   });
 
   board.addEventListener('change', handleStatusTimeChange);
+  board.addEventListener('touchend', forceCommitTimeSelection);
+  board.addEventListener('pointerup', forceCommitTimeSelection);
   // Edge（特にタッチ操作）で change イベントが拾えないケースへのフォールバック
   board.addEventListener('input', (e)=>{
     if(e.target?.name === 'status' || e.target?.name === 'time'){


### PR DESCRIPTION
## 概要
- time セレクトでブラウザが change を発火しないケース向けに、touchend/pointerup 時に値を確定させるフォールバックを追加
- dataset.editing 状態への干渉を避けるため、編集中のガードを入れて既存の制御と競合しないように調整

## テスト
- 未実施（テストスイート指定なし）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ccf3485c88327a713f4f4e8842ba4)