### PR TITLE
タップ処理の多重発火を抑制し状態更新を `change` に集約

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -211,7 +211,6 @@ function buildCandidateField({ id, name, placeholder, type, value }){
 }
 
 let candidatePanelGlobalsBound = false;
-let lastInteractionWasTouch = false;
 function bindCandidatePanelGlobals(){
   if(candidatePanelGlobalsBound) return;
   candidatePanelGlobalsBound = true;
@@ -415,10 +414,6 @@ function applyState(data){
     const localRev  = Number(tr?.dataset.rev || 0);
     if(tr && remoteRev > localRev){ tr.dataset.rev = String(remoteRev); tr.dataset.serverUpdated = String(v.serverUpdated || 0); }
 
-    if(lastInteractionWasTouch){
-      const hasPending = PENDING_ROWS.has(k);
-      console.log('[touch applyState]', { key: k, pending: hasPending, statusValue: s?.value, timeValue: t?.value });
-    }
     ensureTimePrompt(tr);
   });
   recolor();
@@ -511,10 +506,6 @@ function wireEvents(){
     if((t.name==='note' || t.name==='workHours') && key && PENDING_ROWS.has(key)){ t.dataset.editing='1'; }
     else{ delete t.dataset.editing; }
     if(t.name === 'status' || t.name === 'time'){
-      const prev = t.dataset.prevValue;
-      if(prev !== undefined && prev !== t.value){
-        handleStatusTimeChange({ target: t });
-      }
       delete t.dataset.prevValue;
     }
   });
@@ -529,28 +520,16 @@ function wireEvents(){
   });
 
   // 変更（ステータス/時間）
-  const logStatusTimeEvent = (event)=>{
-    const target = event.target;
-    if(!(target && (target.name === 'status' || target.name === 'time'))) return;
-    if(event.type.startsWith('touch')){
-      lastInteractionWasTouch = true;
-    }else if(event.type.startsWith('pointer')){
-      lastInteractionWasTouch = event.pointerType === 'touch';
-    }
-    console.log('[status/time event]', {
-      name: target.name,
-      value: target.value,
-      disabled: target.disabled,
-      type: event.type
-    });
-  };
-
   const handleStatusTimeChange = (e)=>{
     const t = e.target;
     if(!t) return;
     const tr = t.closest('tr'); if(!tr) return;
     const key = tr.dataset.key;
     const prevVal = t.dataset?.prevValue;
+    const lastCommitted = t.dataset?.lastCommittedValue;
+
+    if(prevVal !== undefined && prevVal === t.value) return;
+    if(lastCommitted !== undefined && lastCommitted === t.value) return;
 
     if(t.dataset){
       t.dataset.prevValue = t.value;
@@ -572,6 +551,7 @@ function wireEvents(){
       ensureTimePrompt(tr);
       recolor();
       updateStatusFilterCounts();
+      if(t.dataset) t.dataset.lastCommittedValue = t.value;
       debounceRowPush(key);
       return;
     }
@@ -580,42 +560,11 @@ function wireEvents(){
       t.dataset.editing = '1';
       console.log('[time change]', { key, prev: prevVal, next: t.value });
       ensureTimePrompt(tr);
+      if(t.dataset) t.dataset.lastCommittedValue = t.value;
       debounceRowPush(key);
       return;
     }
   };
 
-  const forceCommitTimeSelection = (event)=>{
-    const timeEl = event.target;
-    if(!(timeEl && timeEl.name === 'time')) return;
-    if(timeEl.dataset?.editing === '1' && timeEl !== document.activeElement) return;
-
-    const selectedOption = timeEl.options?.[timeEl.selectedIndex];
-    if(!selectedOption) return;
-
-    const selectedValue = selectedOption.value;
-    if(timeEl.value !== selectedValue){
-      timeEl.value = selectedValue;
-    }
-
-    timeEl.dispatchEvent(new Event('input', { bubbles: true }));
-    timeEl.dispatchEvent(new Event('change', { bubbles: true }));
-  };
-
-  ['pointerdown','pointerup','touchstart','touchend','touchcancel','click','input','change'].forEach(type=>{
-    board.addEventListener(type, logStatusTimeEvent, true);
-  });
-  ['focus','blur'].forEach(type=>{
-    board.addEventListener(type, logStatusTimeEvent, true);
-  });
-
   board.addEventListener('change', handleStatusTimeChange);
-  board.addEventListener('touchend', forceCommitTimeSelection);
-  board.addEventListener('pointerup', forceCommitTimeSelection);
-  // Edge（特にタッチ操作）で change イベントが拾えないケースへのフォールバック
-  board.addEventListener('input', (e)=>{
-    if(e.target?.name === 'status' || e.target?.name === 'time'){
-      handleStatusTimeChange(e);
-    }
-  });
 }


### PR DESCRIPTION
### Motivation
- Windows/Edge のタッチ操作で `touch/pointer/click/input/change` 等が重複発火し、同一操作で状態更新ロジックが二重に走る問題を解決するため。
- 結果として時刻選択などが上書きされ「2回タップしないと反映されない」現象が発生していた。
- 単一のイベントからのみ状態確定を行い、同一値の再処理を防ぐ設計にすることで安定化を図る。 

### Description
- `js/board.js` のイベント処理を整理し、`change` イベントでの処理に集約してタッチ由来のフォールバックとログ用の多重イベントハンドラを削除した。 
- `focusout` 時点での強制ハンドリングを削除して `change` に責務を一本化した。 
- 同一値の再処理を防ぐガードとして `prevValue` 比較と `dataset.lastCommittedValue` を導入し、既に確定済みの値は再処理しないようにした。 
- タイムセレクト強制コミット用の `forceCommitTimeSelection` と関連のイベント購読を削除し、不要なデバッグログや `lastInteractionWasTouch` 変数を除去した。 

### Testing
- 自動化されたテストは実行していません（未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609911e94c8327843ad4f4adc0b79a)