### PR TITLE
time編集中はステータス変更で時間入力を無効化しない

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -211,7 +211,6 @@ function buildCandidateField({ id, name, placeholder, type, value }){
 }
 
 let candidatePanelGlobalsBound = false;
-let lastInteractionWasTouch = false;
 function bindCandidatePanelGlobals(){
   if(candidatePanelGlobalsBound) return;
   candidatePanelGlobalsBound = true;
@@ -415,10 +414,6 @@ function applyState(data){
     const localRev  = Number(tr?.dataset.rev || 0);
     if(tr && remoteRev > localRev){ tr.dataset.rev = String(remoteRev); tr.dataset.serverUpdated = String(v.serverUpdated || 0); }
 
-    if(lastInteractionWasTouch){
-      const hasPending = PENDING_ROWS.has(k);
-      console.log('[touch applyState]', { key: k, pending: hasPending, statusValue: s?.value, timeValue: t?.value });
-    }
     ensureTimePrompt(tr);
   });
   recolor();
@@ -502,6 +497,9 @@ function wireEvents(){
     if(t && (t.name === 'status' || t.name === 'time')){
       t.dataset.prevValue = t.value;
     }
+    if(t && t.name === 'time' && t.dataset){
+      t.dataset.editingTime = '1';
+    }
   });
   board.addEventListener('focusout', e =>{
     const t=e.target;
@@ -511,11 +509,10 @@ function wireEvents(){
     if((t.name==='note' || t.name==='workHours') && key && PENDING_ROWS.has(key)){ t.dataset.editing='1'; }
     else{ delete t.dataset.editing; }
     if(t.name === 'status' || t.name === 'time'){
-      const prev = t.dataset.prevValue;
-      if(prev !== undefined && prev !== t.value){
-        handleStatusTimeChange({ target: t });
-      }
       delete t.dataset.prevValue;
+    }
+    if(t.name === 'time'){
+      delete t.dataset.editingTime;
     }
   });
   // 入力（備考：入力中は自動更新停止 → setIfNeeded が弾く）
@@ -529,28 +526,16 @@ function wireEvents(){
   });
 
   // 変更（ステータス/時間）
-  const logStatusTimeEvent = (event)=>{
-    const target = event.target;
-    if(!(target && (target.name === 'status' || target.name === 'time'))) return;
-    if(event.type.startsWith('touch')){
-      lastInteractionWasTouch = true;
-    }else if(event.type.startsWith('pointer')){
-      lastInteractionWasTouch = event.pointerType === 'touch';
-    }
-    console.log('[status/time event]', {
-      name: target.name,
-      value: target.value,
-      disabled: target.disabled,
-      type: event.type
-    });
-  };
-
   const handleStatusTimeChange = (e)=>{
     const t = e.target;
     if(!t) return;
     const tr = t.closest('tr'); if(!tr) return;
     const key = tr.dataset.key;
     const prevVal = t.dataset?.prevValue;
+    const lastCommitted = t.dataset?.lastCommittedValue;
+
+    if(prevVal !== undefined && prevVal === t.value) return;
+    if(lastCommitted !== undefined && lastCommitted === t.value) return;
 
     if(t.dataset){
       t.dataset.prevValue = t.value;
@@ -560,11 +545,14 @@ function wireEvents(){
       t.dataset.editing = '1';
       const timeSel = tr.querySelector('select[name="time"]');
       const noteInp = tr.querySelector('input[name="note"]');
+      const isEditingTime = timeSel?.dataset?.editingTime === '1';
       console.log('[status change] before toggle', { key, prev: prevVal, next: t.value, timeDisabled: timeSel?.disabled });
-      toggleTimeEnable(t, timeSel);
+      if(!isEditingTime){
+        toggleTimeEnable(t, timeSel);
+      }
       console.log('[status change] time disabled after toggle', { key, status: t.value, timeDisabled: timeSel?.disabled });
 
-      if(clearOnSet.has(t.value)){
+      if(!isEditingTime && clearOnSet.has(t.value)){
         if(timeSel) timeSel.value = '';
         if(noteInp && isNotePresetValue(noteInp.value)){ noteInp.value = ''; }
       }
@@ -572,6 +560,7 @@ function wireEvents(){
       ensureTimePrompt(tr);
       recolor();
       updateStatusFilterCounts();
+      if(t.dataset) t.dataset.lastCommittedValue = t.value;
       debounceRowPush(key);
       return;
     }
@@ -580,42 +569,11 @@ function wireEvents(){
       t.dataset.editing = '1';
       console.log('[time change]', { key, prev: prevVal, next: t.value });
       ensureTimePrompt(tr);
+      if(t.dataset) t.dataset.lastCommittedValue = t.value;
       debounceRowPush(key);
       return;
     }
   };
 
-  const forceCommitTimeSelection = (event)=>{
-    const timeEl = event.target;
-    if(!(timeEl && timeEl.name === 'time')) return;
-    if(timeEl.dataset?.editing === '1' && timeEl !== document.activeElement) return;
-
-    const selectedOption = timeEl.options?.[timeEl.selectedIndex];
-    if(!selectedOption) return;
-
-    const selectedValue = selectedOption.value;
-    if(timeEl.value !== selectedValue){
-      timeEl.value = selectedValue;
-    }
-
-    timeEl.dispatchEvent(new Event('input', { bubbles: true }));
-    timeEl.dispatchEvent(new Event('change', { bubbles: true }));
-  };
-
-  ['pointerdown','pointerup','touchstart','touchend','touchcancel','click','input','change'].forEach(type=>{
-    board.addEventListener(type, logStatusTimeEvent, true);
-  });
-  ['focus','blur'].forEach(type=>{
-    board.addEventListener(type, logStatusTimeEvent, true);
-  });
-
   board.addEventListener('change', handleStatusTimeChange);
-  board.addEventListener('touchend', forceCommitTimeSelection);
-  board.addEventListener('pointerup', forceCommitTimeSelection);
-  // Edge（特にタッチ操作）で change イベントが拾えないケースへのフォールバック
-  board.addEventListener('input', (e)=>{
-    if(e.target?.name === 'status' || e.target?.name === 'time'){
-      handleStatusTimeChange(e);
-    }
-  });
 }


### PR DESCRIPTION
### Motivation
- Windows + Edge のタッチ操作で `status` 変更が即座に `time` を無効化してしまい、タップ中の時刻入力が破棄される設計上の問題を解消するためです。 
- 先の「イベント整理」では根本原因が解決できなかったため、編集中ロックによる防御が必要でした。 
- また、同一値の重複処理を避けることで余計な更新を防止します。

### Description
- `focusin` / `focusout` で `select[name="time"]` に `dataset.editingTime = '1'` を設定・解除する処理を `js/board.js` に追加しました。 
- `handleStatusTimeChange` 内で `isEditingTime` を確認し、編集中は `toggleTimeEnable` の呼び出しと時間値のクリアを抑止するようにしました。 
- `prevValue` 比較に加えて `dataset.lastCommittedValue` による再処理ガードを導入し、確定済みの値は再処理しないようにしました。 
- Edge 用の即時コミットフォールバックやタッチ／ポインタの詳細なログ・多重イベントハンドラ（および `lastInteractionWasTouch` 変数）は削除しました。

### Testing
- 自動化されたテストは実行していません（未実施）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609911e94c8327843ad4f4adc0b79a)