### PR TITLE
戻り時間の無効化をdisabledではなくクラス/ariaで制御

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -287,6 +287,10 @@
 
   /* 戻り時間入力の促し（外出/会議） */
   td.time{ position:relative; }
+  td.time.time-disabled select{
+    pointer-events:none;
+    opacity:0.45;
+  }
   td.time.need-time select{
     border-color:#ef4444 !important;
     box-shadow:0 0 0 3px rgba(239,68,68,.25);


### PR DESCRIPTION
### Motivation
- Windows + Edge のタッチ操作で `input[type="time"]` を `disabled` に切り替えると OS レベルでタップが破棄されイベントが届かないため操作が無反応になる問題を回避するためです。 
- `disabled` 属性の高速な切替をやめ、表示と操作不可を CSS/ARIA で表現することでタッチ端末での安定性を高めます。 
- 同一値の二重処理を避けるため確定済み値の再処理ガードを入れます。

### Description
- `toggleTimeEnable` を `timeEl.disabled` の直接切替から `aria-disabled` 属性と `td.time` の `time-disabled` クラスおよび `tabIndex` での制御に変更し、Edge のネイティブ time picker 地雷を回避しました。 
- 無効時の見た目・操作不可を CSS 側に追加して `td.time.time-disabled select { pointer-events: none; opacity: 0.45; }` を適用しました。 
- 編集中判定として `focusin`/`focusout` で `data-editingTime` を操作し、編集中は `handleStatusTimeChange` が `toggleTimeEnable` を行わないようにしました。 
- 変更ハンドラに `dataset.lastCommittedValue` による再処理ガードを導入し、ログ参照を `aria-disabled` に合わせて更新すると同時に、従来のタッチ/ポインタ用フォールバックと多量のタッチログ・強制コミット処理を削除しました。 

### Testing
- 自動化されたテストは実行していません（未実施）。
- 変更はローカルでのビルド対象ファイル（`js/board.js` と `styles.css`）に反映されています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609911e94c8327843ad4f4adc0b79a)