### PR TITLE
wrangler.toml に Firebase の vars を追加

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,8 @@ name = "whereabouts"
 main = "CloudflareWorkers_worker.js"
 compatibility_date = "2024-01-14"
 
-# 以下の環境変数は Cloudflare Dashboard または `wrangler secret put` で設定してください
-# - FIREBASE_PROJECT_ID
-# - FIREBASE_CLIENT_EMAIL
-# - FIREBASE_PRIVATE_KEY
+# FIREBASE_PRIVATE_KEY は `wrangler secret put` で設定してください
+
+[vars]
+FIREBASE_PROJECT_ID = "whereabouts-f3388"
+FIREBASE_CLIENT_EMAIL = "firebase-adminsdk-fbsvc@whereabouts-f3388.iam.gserviceaccount.com"


### PR DESCRIPTION
### Motivation
- `wrangler.toml` に Firebase のプロジェクト情報を明示して、秘密鍵をファイルに含めない運用を確実にするため。

### Description
- `wrangler.toml` に `[vars]` セクションを追加し、`FIREBASE_PROJECT_ID` と `FIREBASE_CLIENT_EMAIL` の設定例を追記しました。
- `FIREBASE_PRIVATE_KEY` をファイルに書かないようにコメントを整理し、`wrangler secret put` で登録する旨を明記しました。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696993621dfc83278653381bf418c7b8)