### PR TITLE
styles.css の末尾にユーティリティ/ヘルパークラスを追加

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3863,3 +3863,78 @@
     color: #666;
     font-size: 0.9em;
   }
+
+  /* --- Refactored Utility Classes (Utility / Helper) --- */
+  .u-flex-between-center {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .u-mb-8 {
+    margin-bottom: 8px !important;
+  }
+
+  .u-mt-6 {
+    margin-top: 6px;
+  }
+
+  .u-mt-12 {
+    margin-top: 12px;
+  }
+
+  .u-mt-16 {
+    margin-top: 16px;
+  }
+
+  .u-mr-4 {
+    margin-right: 4px;
+  }
+
+  .u-mb-0 {
+    margin-bottom: 0 !important;
+  }
+
+  .u-text-center {
+    text-align: center;
+  }
+
+  .u-text-gray {
+    color: #6b7280;
+  }
+
+  .u-text-red {
+    color: #d00;
+  }
+
+  .u-font-sm {
+    font-size: 11px;
+  }
+
+  .u-font-13 {
+    font-size: 13px;
+  }
+
+  .u-font-09em {
+    font-size: 0.9em;
+  }
+
+  .u-font-095em {
+    font-size: 0.95em;
+  }
+
+  .u-w-44 {
+    width: 44px;
+  }
+
+  .u-w-64 {
+    width: 64px;
+  }
+
+  .u-w-160 {
+    width: 160px;
+  }
+
+  .u-hidden {
+    display: none;
+  }


### PR DESCRIPTION
### Motivation
- 設計指示書で定義された Utility/Helper クラス群をプロジェクトのスタイルに反映して、HTML/JS で参照されているユーティリティを確実に提供するため。 
- ユーティリティ定義を既存スタイルの最後にまとめて配置し、可読性と管理性を向上させるため。 

### Description
- `styles.css` の末尾にコメント付きのセクション `/* --- Refactored Utility Classes (Utility / Helper) --- */` を追記して、ユーティリティクラス群を追加しました。 
- 追加したクラスは `.u-flex-between-center` から `.u-hidden` までのユーティリティ（余白、フォント、幅、表示制御など）です。 
- 既存のスタイルには影響を与えないよう追記のみを行い、他の定義を変更していません。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696995f9ae708327ae6aec98c696666c)