### PR TITLE
JS読み込み順の整理と`defer`付与

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
                form-action 'self'">
   <link rel="stylesheet" href="styles.css">
 
-  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-app-compat.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-auth-compat.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js" defer></script>
 </head>
 
 <body>
@@ -1183,20 +1183,20 @@
     <div id="board" class="board u-hidden"></div>
   </div>
   <div id="diag" class="diag"></div>
-  <script src="js/config.js"></script>
-  <script src="js/globals.js"></script>
-  <script src="js/utils.js"></script>
-  <script src="js/layout.js"></script>
-  <script src="js/filters.js"></script>
-  <script src="js/board.js"></script>
-  <script src="js/vacations.js"></script>
-  <script src="js/offices.js"></script>
-  <script src="js/auth.js"></script>
-  <script src="js/sync.js"></script>
-  <script src="js/admin.js"></script>
-  <script src="js/tools.js"></script>
-  <script src="js/notices.js"></script>
-  <script src="main.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/globals.js" defer></script>
+  <script src="js/utils.js" defer></script>
+  <script src="js/tools.js" defer></script>
+  <script src="js/auth.js" defer></script>
+  <script src="js/sync.js" defer></script>
+  <script src="js/notices.js" defer></script>
+  <script src="js/vacations.js" defer></script>
+  <script src="js/offices.js" defer></script>
+  <script src="js/layout.js" defer></script>
+  <script src="js/filters.js" defer></script>
+  <script src="js/board.js" defer></script>
+  <script src="js/admin.js" defer></script>
+  <script src="main.js" defer></script>
 
 </body>
 


### PR DESCRIPTION
### Motivation
- HTMLパースをブロックしないようにスクリプトを非同期化し、実行順序を依存関係に沿って安定化させるため。 
- Firebaseなど外部ライブラリを含むロードを遅延させつつ、エントリポイントから確実に初期化できるようにするため。

### Description
- `index.html` の全ての `<script>` タグに `defer` 属性を付与しました（Firebase CDN スクリプトを含む）。
- ローカルスクリプトの読み込み順を依存関係に合わせて整理し、`js/config.js` / `js/globals.js` を先頭に、エントリポイントである `main.js` を末尾にしています。
- 変更対象は `index.html` のみで、既存のスクリプト内容には手を入れていません。

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ab7d30548327bdec527762c563f4)