### PR TITLE
スクリプト順序を元に戻し `defer` を維持

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
                form-action 'self'">
   <link rel="stylesheet" href="styles.css">
 
-  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-app-compat.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-auth-compat.js" defer></script>
+  <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js" defer></script>
 </head>
 
 <body>
@@ -1183,20 +1183,20 @@
     <div id="board" class="board u-hidden"></div>
   </div>
   <div id="diag" class="diag"></div>
-  <script src="js/config.js"></script>
-  <script src="js/globals.js"></script>
-  <script src="js/utils.js"></script>
-  <script src="js/layout.js"></script>
-  <script src="js/filters.js"></script>
-  <script src="js/board.js"></script>
-  <script src="js/vacations.js"></script>
-  <script src="js/offices.js"></script>
-  <script src="js/auth.js"></script>
-  <script src="js/sync.js"></script>
-  <script src="js/admin.js"></script>
-  <script src="js/tools.js"></script>
-  <script src="js/notices.js"></script>
-  <script src="main.js"></script>
+  <script src="js/config.js" defer></script>
+  <script src="js/globals.js" defer></script>
+  <script src="js/utils.js" defer></script>
+  <script src="js/layout.js" defer></script>
+  <script src="js/filters.js" defer></script>
+  <script src="js/board.js" defer></script>
+  <script src="js/vacations.js" defer></script>
+  <script src="js/offices.js" defer></script>
+  <script src="js/auth.js" defer></script>
+  <script src="js/sync.js" defer></script>
+  <script src="js/admin.js" defer></script>
+  <script src="js/tools.js" defer></script>
+  <script src="js/notices.js" defer></script>
+  <script src="main.js" defer></script>
 
 </body>
 


### PR DESCRIPTION
### Motivation
- 前回のスクリプト並び替えで読み込み順が変わりメイン画面のステータスが初期値に戻る問題が発生したため、実行順序を元に戻して影響を避けつつ HTML パースをブロックしないよう `defer` を維持する目的です。

### Description
- `index.html` を更新し、Firebase CDN スクリプトとローカルスクリプト全てに `defer` を追加しつつ、ローカルスクリプトの順序を元の並びに戻しました（`js/config.js`/`js/globals.js` を先頭、`main.js` を末尾）。

### Testing
- 自動化されたテストは実行しておらず、CI や自動テストは未実施です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ab7d30548327bdec527762c563f4)