### PR TITLE
ステータス更新に `updated` タイムスタンプを追加

### DIFF
--- a/CloudflareWorkers_worker.js
+++ b/CloudflareWorkers_worker.js
@@ -99,6 +99,25 @@ export default {
         return json;
       };
       const BATCH_WRITE_SIZE = 200;
+      const MEMBER_UPDATED_FIELD = 'updated';
+      const MEMBER_STATUS_FIELDS = ['status', 'time', 'note'];
+      const MEMBER_STATUS_FIELDS_WITH_WORK_HOURS = [...MEMBER_STATUS_FIELDS, 'workHours'];
+      const getMemberUpdatedTimestamp = (doc) => {
+        const updatedField = doc?.fields?.[MEMBER_UPDATED_FIELD];
+        const updatedValue = Number(
+          updatedField?.integerValue
+          || updatedField?.doubleValue
+          || updatedField?.stringValue
+          || 0
+        );
+        return Number.isFinite(updatedValue) ? updatedValue : 0;
+      };
+      const buildMemberStatusFields = (status, nowTs) => ({
+        status: toFirestoreValue(status.status == null ? '' : String(status.status)),
+        time: toFirestoreValue(status.time == null ? '' : String(status.time)),
+        note: toFirestoreValue(status.note == null ? '' : String(status.note)),
+        updated: toFirestoreValue(nowTs)
+      });
       const firestoreDelete = async (path) => {
         const url = `${baseUrl}/${path}`;
         const res = await fetch(url, {
@@ -165,11 +184,9 @@ export default {
         });
 
         const updatedCandidates = (json.documents || [])
-          .map(doc => doc.updateTime)
-          .filter(Boolean)
-          .map(v => Date.parse(v))
-          .filter(v => Number.isFinite(v));
-        const updated = updatedCandidates.length ? Math.max(...updatedCandidates) : Date.now();
+          .map(getMemberUpdatedTimestamp)
+          .filter(v => Number.isFinite(v) && v > 0);
+        const updated = updatedCandidates.length ? Math.max(...updatedCandidates) : 0;
 
         return new Response(JSON.stringify({
           ok: true,
@@ -183,11 +200,9 @@ export default {
         const json = await firestoreFetch(`offices/${officeId}/members?pageSize=300`);
         const dataMap = {};
         const updatedCandidates = (json.documents || [])
-          .map(doc => doc.updateTime)
-          .filter(Boolean)
-          .map(v => Date.parse(v))
-          .filter(v => Number.isFinite(v));
-        const updated = updatedCandidates.length ? Math.max(...updatedCandidates) : Date.now();
+          .map(getMemberUpdatedTimestamp)
+          .filter(v => Number.isFinite(v) && v > 0);
+        const updated = updatedCandidates.length ? Math.max(...updatedCandidates) : 0;
         (json.documents || []).forEach(doc => {
           const f = doc.fields || {};
           dataMap[doc.name.split('/').pop()] = {
@@ -388,6 +403,7 @@ export default {
         const incomingData = incoming.data || {};
         const full = !!incoming.full;
         const writes = [];
+        const nowTs = Date.now();
 
         if (full) {
           const existing = await firestoreFetch(`offices/${officeId}/members?pageSize=300`);
@@ -402,22 +418,19 @@ export default {
                   status: toFirestoreValue(''),
                   time: toFirestoreValue(''),
                   note: toFirestoreValue(''),
-                  workHours: toFirestoreValue('')
+                  workHours: toFirestoreValue(''),
+                  updated: toFirestoreValue(nowTs)
                 }
               },
-              updateMask: { fieldPaths: ['status', 'time', 'note', 'workHours'] }
+              updateMask: { fieldPaths: [...MEMBER_STATUS_FIELDS_WITH_WORK_HOURS, MEMBER_UPDATED_FIELD] }
             }));
           writes.push(...clears);
         }
 
         Object.keys(incomingData).forEach((userId) => {
           const s = incomingData[userId] || {};
-          const fields = {
-            status: toFirestoreValue(s.status == null ? '' : String(s.status)),
-            time: toFirestoreValue(s.time == null ? '' : String(s.time)),
-            note: toFirestoreValue(s.note == null ? '' : String(s.note))
-          };
-          const updateMask = ['status', 'time', 'note'];
+          const fields = buildMemberStatusFields(s, nowTs);
+          const updateMask = [...MEMBER_STATUS_FIELDS, MEMBER_UPDATED_FIELD];
           if (Object.prototype.hasOwnProperty.call(s, 'workHours')) {
             fields.workHours = toFirestoreValue(s.workHours == null ? '' : String(s.workHours));
             updateMask.push('workHours');
@@ -462,22 +475,14 @@ export default {
       if (action === 'set') {
         const officeId = formData.get('tokenOffice') || 'nagoya_chuo';
         const updates = JSON.parse(formData.get('data')).data || {};
+        const nowTs = Date.now();
+        const updateMask = [...MEMBER_STATUS_FIELDS_WITH_WORK_HOURS, MEMBER_UPDATED_FIELD];
 
         const promises = Object.keys(updates).map(async (userId) => {
           const s = updates[userId];
-          const url = `${baseUrl}/offices/${officeId}/members/${userId}?updateMask.fieldPaths=status&updateMask.fieldPaths=time&updateMask.fieldPaths=note&updateMask.fieldPaths=workHours`;
-          return fetch(url, {
-            method: 'PATCH',
-            headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              fields: {
-                status: { stringValue: s.status || '' },
-                time: { stringValue: s.time || '' },
-                note: { stringValue: s.note || '' },
-                workHours: { stringValue: s.workHours || '' }
-              }
-            })
-          });
+          const fields = buildMemberStatusFields(s, nowTs);
+          fields.workHours = toFirestoreValue(s.workHours == null ? '' : String(s.workHours));
+          return firestorePatch(`offices/${officeId}/members/${encodeURIComponent(userId)}`, { fields }, updateMask);
         });
         await Promise.all(promises);
         return new Response(JSON.stringify({ ok: true }), { headers: corsHeaders });


### PR DESCRIPTION
### Motivation

- メンバーのステータス更新時にサーバ側の更新時刻を Firestore フィールドとして保存し、クライアント側の差分判定やキャッシュ更新を安定させるため。 
- 既存ドキュメントに `updated` が無い場合は古いデータとみなして扱うことで、明示的に更新されたデータを正しく優先できるようにするため。 

### Description

- `MEMBER_UPDATED_FIELD`、`MEMBER_STATUS_FIELDS`、`MEMBER_STATUS_FIELDS_WITH_WORK_HOURS` の定数と、ドキュメントから `updated` を読み取る `getMemberUpdatedTimestamp` と書き込み用の `buildMemberStatusFields` ヘルパーを追加しました。 
- `getConfig` と `getFor` の updated 集計をドキュメントの `updated` フィールドから計算するように変更し、未設定は `0` として扱うようにしました。 
- `setFor` の full モードでクリアする更新に `updated: Date.now()` を含め、該当フィールドを `updateMask` に追加しました。 
- `set`（個別ステータス更新）でも `updated: Date.now()` を書き込み、`updateMask` に `updated` を含めるようにして `firestorePatch` を使用するように置換しました。 

### Testing

- 自動テストは実行していません（なし）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d9adc792c83279c7ddcecf57536f2)