### PR TITLE
`action==='get'` のレスポンスを KV キャッシュ化し ETag を追加、書き込み時にキャッシュ更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ npx wrangler secret put FIREBASE_SERVICE_ACCOUNT
 
 ```
 
+#### KVキャッシュの設定
+
+`action === "get"` のレスポンスをKVにキャッシュするため、KVネームスペースを作成して `wrangler.toml` の `kv_namespaces` にIDを設定します。
+
+```bash
+npx wrangler kv:namespace create STATUS_CACHE
+```
+
+`wrangler.toml` の `STATUS_CACHE_TTL_SEC` と `STATUS_CACHE_WARM_ON_WRITE` でキャッシュのTTLと書き込み時のウォームアップを制御します。
+
 #### デプロイ
 
 ```bash

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,12 @@ compatibility_date = "2024-01-14"
 
 # FIREBASE_PRIVATE_KEY は `wrangler secret put` で設定してください
 
+kv_namespaces = [
+  { binding = "STATUS_CACHE", id = "STATUS_CACHE_KV_ID" }
+]
+
 [vars]
 FIREBASE_PROJECT_ID = "whereabouts-f3388"
 FIREBASE_CLIENT_EMAIL = "firebase-adminsdk-fbsvc@whereabouts-f3388.iam.gserviceaccount.com"
+STATUS_CACHE_TTL_SEC = "30"
+STATUS_CACHE_WARM_ON_WRITE = "true"


### PR DESCRIPTION
### Motivation
- Firestore への読み取りを減らしレスポンス遅延と料金を削減するために `action === 'get'` の結果を Cloudflare KV にキャッシュします。
- キャッシュ鮮度を `TTL`（またはキャッシュ作成時刻）で管理して外部からの書き込み変化を吸収できるようにします。
- クライアント側での再利用を促進するために `ETag` / `If-None-Match` による 304 応答を提供します。

### Description
- `CloudflareWorkers_worker.js` に KV キャッシュ用ヘルパーを追加し、`STATUS_CACHE` バインディングと環境変数 `STATUS_CACHE_TTL_SEC` / `STATUS_CACHE_WARM_ON_WRITE` を参照するようにしました（`parsePositiveNumber`, `readStatusCacheRaw`, `readStatusCacheFresh`, `writeStatusCache`, `buildStatusCacheEntry`, `updateStatusCacheAfterWrite`, `buildStatusEtag` 等を実装）。
- `action === 'get'` の処理はまず KV の新鮮なキャッシュを参照し存在すればそれを返すようにし、`If-None-Match` ヘッダを確認して 304 を返せるようにしました；キャッシュが無ければ Firestore から取得してキャッシュを書き込みます。
- `action === 'set'` と `action === 'setFor'` 実行後にキャッシュを更新する処理を呼び出すようにして、書き込み直後の読み出しで Firestore を叩かずに済むようにしました（`preserveWorkHours` やフルアップデート時の `clearIds` を考慮）。
- `wrangler.toml` に `kv_namespaces` のバインディングとデフォルトの `STATUS_CACHE_TTL_SEC` / `STATUS_CACHE_WARM_ON_WRITE` を追加し、`README.md` に KV ネームスペース作成手順と設定説明を追記しました。

### Testing
- 自動化されたテストは実行していません（`no automated tests run`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d9e24f5408327b50bd49172fa18ac)