### PR TITLE
初回同期と設定取得でKVキャッシュを有効化

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -181,10 +181,7 @@ async function startLegacyPolling(immediate) {
   const pollAction = async (isFirstRun = false) => {
     const payload = { action: 'get', token: SESSION_TOKEN, since: lastSyncTimestamp };
     
-    // ★追加: 初回実行時はキャッシュを無視させる
-    if (isFirstRun) {
-      payload.nocache = '1';
-    }
+    // 初回でもキャッシュを活用するため nocache を付与しない
 
     const r = await apiPost(payload);
     if (r?.error === 'unauthorized') {
@@ -256,7 +253,7 @@ function startRemoteSync(immediate) {
 }
 
 async function fetchConfigOnce() {
-  const cfg = await apiPost({ action: 'getConfig', token: SESSION_TOKEN, nocache: '1' });
+  const cfg = await apiPost({ action: 'getConfig', token: SESSION_TOKEN });
   if (cfg?.error === 'unauthorized') {
     await logout();
     return;


### PR DESCRIPTION
### Motivation
- FirestoreのReadを減らすため、クライアントからCloudflare Workerへ送っていた`nocache: '1'`を除去し、WorkerのKVキャッシュを活用させる。

### Description
- `js/sync.js`で`startLegacyPolling`の初回ポーリングから`nocache`パラメータを削除して初回でもKVを利用するように変更した。 
- `js/sync.js`の`fetchConfigOnce`で`getConfig`リクエストの`nocache`を除去して設定取得にキャッシュを使うように変更した。 

### Testing
- 自動テストは実行しておらず、テストは行われていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c56783488327a07a2253028d2f40)