### PR TITLE
KVキャッシュTTLを7日へ延長し、夜間ポーリング抑制を追加

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -8,6 +8,7 @@ const CONFIG = {
         : "https://whereabouts.taka-hiyo.workers.dev",
 
     remotePollMs: 60000,       // 10秒 -> 60秒へ変更（リクエスト数 1/6）
+    nightPollMs: 3600000,      // 夜間時: 1時間 (60分 * 60秒 * 1000)
     configPollMs: 300000,      // 30秒 -> 5分へ変更
     eventSyncIntervalMs: 10 * 60 * 1000, // 5分 -> 10分へ変更
     tokenDefaultTtl: 3600000,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,7 +15,7 @@ kv_namespaces = [
 [vars]
 FIREBASE_PROJECT_ID = "whereabouts-f3388"
 FIREBASE_CLIENT_EMAIL = "firebase-adminsdk-fbsvc@whereabouts-f3388.iam.gserviceaccount.com"
-STATUS_CACHE_TTL_SEC = "60"
+STATUS_CACHE_TTL_SEC = "604800"
 
 # ▼▼▼ 開発環境 (dev) の設定 ▼▼▼
 [env.dev]
@@ -30,4 +30,4 @@ id = "695bec76282e488c8d7b76fd5f0a1f4f"
 [env.dev.vars]
 FIREBASE_PROJECT_ID = "whereabouts-f3388"
 FIREBASE_CLIENT_EMAIL = "firebase-adminsdk-fbsvc@whereabouts-f3388.iam.gserviceaccount.com"
-STATUS_CACHE_TTL_SEC = "60"
+STATUS_CACHE_TTL_SEC = "604800"


### PR DESCRIPTION
### Motivation
- KVの読み取り課金を抑えるためにキャッシュ有効期限を長く設定し、読み取りリクエストを削減する。 
- クライアント側の夜間（22:00–07:00）の自動更新頻度を下げてリクエスト消費を抑える。 
- 将来の拠点別運用（時差・24Hシフト等）に対応しやすいように柔軟な実装を行う。 

### Description
- `wrangler.toml` の `STATUS_CACHE_TTL_SEC` を本番および `env.dev.vars` 両方で `"604800"`（7日）に変更した。 
- `js/config.js` に夜間用間隔 `nightPollMs: 3600000`（1時間）を追加し、既存の `remotePollMs` を引き続き使用するようにした。 
- `js/sync.js` に `let lastPollTime = 0;` を追加し、`startLegacyPolling` 内に夜間判定（22:00–07:00）と `requiredInterval` に基づくポーリングスキップロジックを実装した（`CONFIG.remotePollMs` / `CONFIG.nightPollMs` を参照）。 
- 同ファイルで同期時刻が進んだ際に `localStorage` の `STORAGE_KEY_SYNC` に保存する処理を追加し、起動時に復元する流れを保持している。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69718e4d43c883278c52177f4e14975a)