### PR TITLE
お知らせ表示とイベント保存/削除の不具合修正

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -673,6 +673,16 @@ async function handleMemberSave() {
 
 /* お知らせ管理UI */
 btnAddNotice.addEventListener('click', () => addNoticeEditorItem());
+function resolveNoticeVisibility(item) {
+  if (!item || typeof item !== 'object') return true;
+  if (Object.prototype.hasOwnProperty.call(item, 'visible')) {
+    return item.visible !== false;
+  }
+  if (Object.prototype.hasOwnProperty.call(item, 'display')) {
+    return item.display !== false;
+  }
+  return true;
+}
 btnLoadNotices.addEventListener('click', async () => {
   const office = selectedOfficeId(); if (!office) return;
   try {
@@ -685,9 +695,9 @@ btnLoadNotices.addEventListener('click', async () => {
         addNoticeEditorItem();
       } else {
         res.notices.forEach((n, idx) => {
-          const visible = (n && n.visible !== false) ? true : (n && n.display !== false);
+          const visible = resolveNoticeVisibility(n);
           const id = n && (n.id != null ? n.id : (n.noticeId != null ? n.noticeId : idx));
-          addNoticeEditorItem(n.title, n.content, visible !== false, id);
+          addNoticeEditorItem(n.title, n.content, visible, id);
         });
       }
       toast('お知らせを読み込みました');
@@ -1641,9 +1651,9 @@ async function autoLoadNoticesOnAdminOpen() {
         addNoticeEditorItem();
       } else {
         res.notices.forEach((n, idx) => {
-          const visible = (n && n.visible !== false) ? true : (n && n.display !== false);
+          const visible = resolveNoticeVisibility(n);
           const id = n && (n.id != null ? n.id : (n.noticeId != null ? n.noticeId : idx));
-          addNoticeEditorItem(n.title, n.content, visible !== false, id);
+          addNoticeEditorItem(n.title, n.content, visible, id);
         });
       }
     }


### PR DESCRIPTION
### Motivation
- 管理画面で非表示にしたお知らせのチェック状態が正しく復元されない問題を解消するための修正。 
- 管理画面でお知らせを削除しても Firestore 側で削除が反映されず再読込で復活する問題を解決するため。 
- イベント（vacation）の作成/編集/削除が正しく永続化されない、単件ペイロードを扱えないなどの不具合を修正するため。 

### Description
- `js/admin.js` に `resolveNoticeVisibility` を追加し、`visible`/`display` フラグの解釈を統一して管理画面のロード処理で使用するようにした（`btnLoadNotices` と `autoLoadNoticesOnAdminOpen` の利用箇所）。
- `CloudflareWorkers_worker.js` に Firestore 用の削除ヘルパー `firestoreDelete` を追加し、`setNotices` 処理で送信されなかった（削除対象の）既存ドキュメントを削除するロジックを追加したことで管理画面からの削除を永続化するようにした。 
- `setVacation` 処理を拡張して単一ペイロード（`data`）または配列（`vacations`）の両方を受け付けるようにし、`membersBits`/`isVacation`/`note`/`noticeId`/`noticeTitle`/`order`/`office` 等のフィールドを Firestore に保存するようにした。 
- `getVacation` のレスポンスを拡張して読み出し時に上記フィールド（`isVacation`/`note`/`noticeId`/`noticeTitle`/`order`/`office`）を返すようにした。 
- 新たに `deleteVacation` アクションを追加し、イベントの削除を Cloudflare Worker 側で実行できるようにした（キャッシュ削除含む）。

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69797016e4a483279745dc671bf3aac3)