### PR TITLE
apiPost を JSON ({data:...}) 送信に変更し、Worker 側で互換フォーマットを解析

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -44,7 +44,17 @@ function sanitizeText(s) {
 
 function el(tag, attrs = {}, children = []) { const e = document.createElement(tag); for (const [k, v] of Object.entries(attrs || {})) { if (v == null) continue; if (k === 'class') e.className = v; else if (k === 'text') e.textContent = String(v); else e.setAttribute(k, String(v)); } (children || []).forEach(c => e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c)); return e; }
 function qsEncode(obj) { const p = new URLSearchParams(); Object.entries(obj || {}).forEach(([k, v]) => { if (v == null) return; p.append(k, String(v)); }); return p.toString(); }
+const API_POST_CONTENT_TYPE = 'application/json';
+const API_POST_LEGACY_CONTENT_TYPE = 'application/x-www-form-urlencoded';
 async function apiPost(params, timeout = 20000) {
+  /**
+   * apiPost 送信仕様:
+   * - 現行: Content-Type: application/json
+   *   - body: { data: { ...params, tokenOffice?, tokenRole? } }
+   * - 旧仕様 (互換): application/x-www-form-urlencoded
+   *   - body: key=value&...
+   * data は常にオブジェクトとして送信する。
+   */
   const payload = { ...params };
   if (typeof CURRENT_OFFICE_ID !== 'undefined' && CURRENT_OFFICE_ID) {
     payload.tokenOffice = CURRENT_OFFICE_ID;
@@ -52,7 +62,8 @@ async function apiPost(params, timeout = 20000) {
   if (typeof CURRENT_ROLE !== 'undefined' && CURRENT_ROLE) {
     payload.tokenRole = CURRENT_ROLE;
   }
-  const controller = new AbortController(); const t = setTimeout(() => controller.abort(), timeout); try { const endpoint = (typeof CONFIG !== 'undefined' && CONFIG.remoteEndpoint) ? CONFIG.remoteEndpoint : "https://presence-proxy-prod.taka-hiyo.workers.dev"; const res = await fetch(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: qsEncode(payload), signal: controller.signal, credentials: 'omit', cache: 'no-store' }); const ct = (res.headers.get('content-type') || '').toLowerCase(); if (!ct.includes('application/json')) return { ok: false, error: 'invalid_content_type' }; return await res.json(); } catch (err) { console.error(err); return { ok: false, error: err }; } finally { clearTimeout(t); }
+  const body = JSON.stringify({ data: payload });
+  const controller = new AbortController(); const t = setTimeout(() => controller.abort(), timeout); try { const endpoint = (typeof CONFIG !== 'undefined' && CONFIG.remoteEndpoint) ? CONFIG.remoteEndpoint : "https://presence-proxy-prod.taka-hiyo.workers.dev"; const res = await fetch(endpoint, { method: 'POST', headers: { 'Content-Type': API_POST_CONTENT_TYPE }, body, signal: controller.signal, credentials: 'omit', cache: 'no-store' }); const ct = (res.headers.get('content-type') || '').toLowerCase(); if (!ct.includes('application/json')) return { ok: false, error: 'invalid_content_type' }; return await res.json(); } catch (err) { console.error(err); return { ok: false, error: err }; } finally { clearTimeout(t); }
 }
 /* セッションメタ(F5耐性) */
 function saveSessionMeta() { try { sessionStorage.setItem(SESSION_ROLE_KEY, CURRENT_ROLE || 'user'); sessionStorage.setItem(SESSION_OFFICE_KEY, CURRENT_OFFICE_ID || ''); sessionStorage.setItem(SESSION_OFFICE_NAME_KEY, CURRENT_OFFICE_NAME || ''); } catch { } }


### PR DESCRIPTION
### Motivation
- クライアントと Worker 間の送信形式を `Content-Type: application/json` に統一し、`data` を常にオブジェクトとして渡すことで仕様を明確化するため。 
- 既存のクライアント挙動を壊さないように、Worker 側で旧フォーマット（URLエンコード／フラットJSON）を当面サポートするため。 

### Description
- `js/utils.js` の `apiPost` を更新して、送信を `Content-Type: application/json` に統一し、ボディを `JSON.stringify({ data: payload })` として送るように変更し、仕様コメントを追加した。 
- `js/utils.js` に `API_POST_CONTENT_TYPE` と `API_POST_LEGACY_CONTENT_TYPE` 定数を追加して意図を明示した。 
- `CloudflareWorkers_worker.js` に受信仕様コメントを追加し、`parseJsonParam` と `resolveRequestData` を導入して `{ data: {...} }` ラップ形式を優先的に展開しつつ、既存の URL エンコード／フラット JSON も解析できるようにした。 
- Worker のパラメータ取得を `requestData` 経由の `getParam` に切り替え、互換性を維持したまま新形式を扱えるようにした。 

### Testing
- 自動化されたテストは実行していません（実行なし）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69834bb604c8832799010103cf4c3cf7)