### PR TITLE
D1移行での公開拠点取得を互換化してログイン障害を解消

### DIFF
--- a/CloudflareWorkers_worker.js
+++ b/CloudflareWorkers_worker.js
@@ -215,8 +215,9 @@ export default {
 
       /* --- PUBLIC LIST OFFICES --- */
       if (action === 'publicListOffices') {
-        const offices = await env.DB.prepare('SELECT id, name FROM offices WHERE is_public = 1')
-          .all();
+        const offices = await env.DB.prepare(
+          "SELECT id, name FROM offices WHERE is_public IS NULL OR is_public = 1 OR lower(CAST(is_public AS TEXT)) = 'true'"
+        ).all();
         return new Response(JSON.stringify({ ok: true, offices: offices.results }), { headers: corsHeaders });
       }
 


### PR DESCRIPTION
### Motivation
- D1（SQL）へ移行した環境で `publicListOffices` が空になりログインできなくなるケースを防ぐため、既存の boolean/文字列/NULL の値を考慮した互換処理を入れました。

### Description
- `CloudflareWorkers_worker.js` の `publicListOffices` クエリを `'SELECT id, name FROM offices WHERE is_public = 1'` から `is_public IS NULL OR is_public = 1 OR lower(CAST(is_public AS TEXT)) = 'true'` を許容する SQL に変更しました。

### Testing
- 自動化されたテストは実行していません（差分は SQL 条件のみのため、既存挙動への影響を最小化する意図の修正です）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698368563b08832780688f0042a09620)