### PR TITLE
一覧出力の業務時間・戻り時間カラム幅を調整

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1898,21 +1898,27 @@ if (btnPrintList) {
 
       if (oneTable) {
         // 全員一括の1つのリスト（1人1行テーブル）
-        // ★ 列幅の定義箇所 (SSOT): colgroup のみ
-        //   ※ .print-col-* クラスは使わない（styles.css の !important と競合するため）
+        const printOneTableColumns = [
+          { key: 'name', label: '氏名', width: '13%' },
+          { key: 'workHours', label: '業務時間', width: '14%' },
+          { key: 'status', label: '状態', width: '12%' },
+          { key: 'time', label: '戻り', width: '10%' },
+          { key: 'tomorrowPlan', label: '明日の予定', width: '18%' },
+          { key: 'note', label: '備考', width: '33%' }
+        ];
+
         const container = document.createElement('div');
         container.className = 'print-list-container';
 
         const table = document.createElement('table');
         table.className = 'print-one-col-table';
 
-        // ★ SSOT: 列幅はここだけで定義する
-        // 氏名13% + 時間12% + 状態12% + 戻り7% + 予定20% + 備考36% = 100%
+        // ★ SSOT: 列幅は printOneTableColumns のみで管理
         const colgroup = document.createElement('colgroup');
-        const colWidths = ['13%', '12%', '12%', '7%', '20%', '36%'];
-        colWidths.forEach(w => {
+        printOneTableColumns.forEach(({ width, key }) => {
           const col = document.createElement('col');
-          col.style.width = w;
+          col.className = `print-one-col-${key}`;
+          col.style.width = width;
           colgroup.appendChild(col);
         });
         table.appendChild(colgroup);
@@ -1921,27 +1927,24 @@ if (btnPrintList) {
         const thead = document.createElement('thead');
         const headerRow = document.createElement('tr');
 
-        const headers = ['氏名', '業務時間', '状態', '戻り', '明日の予定', '備考'];
-        headers.forEach(h => {
+        printOneTableColumns.forEach(({ label, key }) => {
           const th = document.createElement('th');
-          th.textContent = h;
+          th.className = `print-one-col-${key}`;
+          th.textContent = label;
           headerRow.appendChild(th);
         });
 
         thead.appendChild(headerRow);
         table.appendChild(thead);
 
-        // TBODY: 1人1行（クラスなしでセル生成）
+        // TBODY: 1人1行
         const tbody = document.createElement('tbody');
         list.forEach(m => {
           const tr = document.createElement('tr');
-          const values = [
-            m.name || '', m.workHours || '', m.status || '',
-            m.time || '', m.tomorrowPlan || '', m.note || ''
-          ];
-          values.forEach(v => {
+          printOneTableColumns.forEach(({ key }) => {
             const td = document.createElement('td');
-            td.textContent = v;
+            td.className = `print-one-col-${key}`;
+            td.textContent = m[key] || '';
             tr.appendChild(td);
           });
           tbody.appendChild(tr);

--- a/print-list.css
+++ b/print-list.css
@@ -5,6 +5,11 @@
 
 @media print {
 
+    :root {
+        --print-one-col-work-min-width: 88px;
+        --print-one-col-time-min-width: 72px;
+    }
+
     /* ==========================================================================
    * 1. 表示切替 — 一覧出力時は他の要素をすべて隠す
    * styles.css Block1 の body>*:not(#eventModal) { display:none } を打ち消し
@@ -58,6 +63,19 @@
         border-collapse: collapse !important;
         border-spacing: 0 !important;
         table-layout: fixed !important;
+        min-width: calc(120px + var(--print-one-col-work-min-width) + 100px + var(--print-one-col-time-min-width) + 150px + 200px) !important;
+    }
+
+    .print-one-col-table th.print-one-col-work,
+    .print-one-col-table td.print-one-col-work {
+        min-width: var(--print-one-col-work-min-width) !important;
+        white-space: nowrap !important;
+    }
+
+    .print-one-col-table th.print-one-col-time,
+    .print-one-col-table td.print-one-col-time {
+        min-width: var(--print-one-col-time-min-width) !important;
+        white-space: nowrap !important;
     }
 
     .print-one-col-table th,


### PR DESCRIPTION
## 概要
設定パネルの「一覧出力（PDF出力）」で、全ユーザーを1テーブルで出力した際に「業務時間」「戻り」が潰れて表示崩れする問題に対応しました。

## 変更内容
- `js/admin.js`
  - One Table 出力の列定義を `printOneTableColumns` に集約（SSOT化）
  - 列ごとの `label / key / width` を1箇所で管理
  - `th`/`td`/`col` に列識別クラス（`print-one-col-*`）を付与
- `print-list.css`
  - One Table 印刷用に「業務時間」「戻り」列の最小幅変数を追加
    - `--print-one-col-work-min-width`
    - `--print-one-col-time-min-width`
  - 上記列に `min-width` と `white-space: nowrap` を適用
  - テーブル全体に最小幅を設定し、列の極端な圧縮を防止

## 期待効果
- 「業務時間」「戻り」の文字が途中折返しや潰れで崩れにくくなる
- 列幅の調整ポイントがSSOT化され、今後の微調整がしやすくなる

## 影響範囲
- 一覧出力（PDF出力）の One Table レイアウトのみ
- 通常画面の在席ボードや編集UIには影響なし

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c7181b8c8327a8a1bad34cd74343)