### PR TITLE
fix(print): 一覧2段テーブルの備考列が境界化／欠落する問題をSSOT列幅で修正

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3816,28 +3816,13 @@ td.time.need-time select:focus~.time-hint {
 }
 
 /* 列幅定義 (左・右共通) */
-.print-col-name {
-  width: 14% !important;
-}
-
-.print-col-work {
-  width: 14% !important;
-}
-
-.print-col-status {
-  width: 8% !important;
-}
-
-.print-col-time {
-  width: 8% !important;
-}
-
-.print-col-next {
-  width: 12% !important;
-}
-
-/* 備考は残り全て */
-.print-col-note {
+/* 列幅は js/admin.js の colgroup（SSOT）で管理 */
+.print-two-col-table .print-col-name,
+.print-two-col-table .print-col-work,
+.print-two-col-table .print-col-status,
+.print-two-col-table .print-col-time,
+.print-two-col-table .print-col-next,
+.print-two-col-table .print-col-note {
   width: auto !important;
 }
 
@@ -4166,6 +4151,12 @@ td.time.need-time select:focus~.time-hint {
   column-count: 2;
   column-gap: 20px;
   width: 100%;
+}
+
+/* 1テーブル出力は段組みしない（4段落化防止） */
+.print-list-container--one-table {
+  column-count: 1;
+  column-gap: 0;
 }
 
 .print-group-section {


### PR DESCRIPTION
### Motivation
- oneTable（1テーブル・左右2段）出力で左段の「備考」が中央境界化し、右段の「備考」が表示されない問題を解消するための対応です。 
- 列幅決定が散在しており `table-layout: fixed` と競合して不安定になっていたため、列幅を単一ソース（SSOT）で一元管理する必要がありました。

### Description
- 列定義を `PRINT_LIST_COLUMNS` に集約し、各列に `ratio` を追加して列比率を SSOT 化しました（`js/admin.js`）。
- 左右それぞれの列と中央セパレータを含む `colgroup` を生成する `appendPrintColGroup` を追加し、`oneTable` 出力時に必ず `colgroup` を適用するようにしました（`js/admin.js`）。
- ヘッダー/行生成を `appendHeaderCells` / `appendMemberCells` に共通化して左右のセル整合を保ち、1行に左右2名を表示するレンダリングに変更しました（`js/admin.js`）。
- 旧来の固定幅 CSS（`.print-col-*` の明示幅）を廃止し、`print-two-col-table` は `colgroup` 主導に統一するために CSS を整理しました（`styles.css`）。

### Testing
- `node --check js/admin.js` を実行して構文エラーがないことを確認しました（成功）。
- ローカルサーバーを `python3 -m http.server 4173` で起動して表示確認を行いました（成功）。
- Playwright スクリプトで左右それぞれの「備考」列が独立して表示されることを再現しスクリーンショットを取得して確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997cb5a95888327832fc60a434f1abb)