### PR TITLE
同期自己修復パラメータをSSOT化し sync.js のマジックナンバーを排除

### DIFF
--- a/SSOT_GUIDE.md
+++ b/SSOT_GUIDE.md
@@ -249,3 +249,18 @@ setTimeout(callback, TIMEOUTS.DEFAULT_MS);
 
 - [CORE_PRINCIPLES.md](./CORE_PRINCIPLES.md) - 基本原則
 - [COMMENT_GUIDE.md](./COMMENT_GUIDE.md) - 定数へのコメント付与規則
+
+
+---
+
+## 同期自己修復パラメータ一覧（変更窓口）
+
+同期の自己修復で使用する値は **`js/constants/timing.js` を既定値のSSOT**、**`js/config.js` の `CONFIG.syncSelfHeal` を環境上書き窓口**とする。運用で値を変更する場合は、この2ファイル以外を編集しないこと。
+
+| パラメータ | 既定値定数（timing.js） | 上書きキー（config.js） | 運用意図 |
+|---|---|---|---|
+| rev救済ウィンドウ | `DEFAULT_SYNC_REV_RESCUE_WINDOW_MS` | `syncSelfHeal.revRescueWindowMs` | rev同値かつ `serverUpdated` 進行時の救済適用範囲 |
+| キャッシュ寿命 | `DEFAULT_SYNC_CACHE_TTL_MS` | `syncSelfHeal.cacheTtlMs` | 古い同期キャッシュを破棄して自己修復を優先する期限 |
+| 競合連続判定 | `DEFAULT_SYNC_CONFLICT_STREAK_WARN_THRESHOLD` | `syncSelfHeal.conflictStreakWarnThreshold` | 競合多発を検知して警告を出すしきい値 |
+
+実装側（`js/sync.js`）は上記キーのみ参照し、数値リテラルを直接書かないこと。

--- a/js/config.js
+++ b/js/config.js
@@ -26,6 +26,16 @@ const CONFIG = {
     configPollMs: 300000,      // 30秒 -> 5分へ変更
     eventSyncIntervalMs: 10 * 60 * 1000, // 5分 -> 10分へ変更
     tokenDefaultTtl: 3600000,
+    // 同期自己修復パラメータ（既定値は js/constants/timing.js）。
+    // 変更窓口は SSOT_GUIDE.md の『同期自己修復パラメータ一覧』に一本化すること。
+    syncSelfHeal: {
+        // rev が同値でも serverUpdated の進みを許容する救済ウィンドウ。
+        revRescueWindowMs: 180000,
+        // 復元対象とみなす同期キャッシュの寿命。期限超過時は破棄して再同期。
+        cacheTtlMs: 21600000,
+        // 競合が連続した場合の警告しきい値。運用で多発監視する。
+        conflictStreakWarnThreshold: 3
+    },
     syncLog: {
         skipWarnThreshold: 3
     },

--- a/js/constants/storage.js
+++ b/js/constants/storage.js
@@ -37,6 +37,7 @@ const NOTICE_COLLAPSE_STORAGE_KEY = 'noticeAreaCollapsed';
 // ============================================
 /**
  * 状態キャッシュキー（CONFIG.storageKeysから参照）
+ * 値は sync.js で { savedAt, state } の自己修復用エンベロープ保存にも利用される。
  * @deprecated CONFIG.storageKeys.stateCache を使用すること
  */
 const STORAGE_KEY_CACHE_FALLBACK = 'whereabouts_state_cache';

--- a/js/constants/timing.js
+++ b/js/constants/timing.js
@@ -29,6 +29,27 @@ const DEFAULT_EVENT_SYNC_INTERVAL_MS = 600000; // 10分
 const DEFAULT_TOKEN_TTL_MS = 3600000;
 
 // ============================================
+// 同期自己修復（デフォルト値）
+// ============================================
+/**
+ * rev救済ウィンドウ（ミリ秒）- CONFIG.syncSelfHeal.revRescueWindowMs で上書き可
+ * revが同値でも serverUpdated がこの範囲内で進んでいれば追随を許可する。
+ */
+const DEFAULT_SYNC_REV_RESCUE_WINDOW_MS = 180000;
+
+/**
+ * 同期キャッシュ寿命（ミリ秒）- CONFIG.syncSelfHeal.cacheTtlMs で上書き可
+ * 期限切れキャッシュは復元せず、破損時の自己修復を優先する。
+ */
+const DEFAULT_SYNC_CACHE_TTL_MS = 21600000;
+
+/**
+ * 競合連続判定しきい値（回）- CONFIG.syncSelfHeal.conflictStreakWarnThreshold で上書き可
+ * 連続競合の多発を早期検知するための警告しきい値。
+ */
+const DEFAULT_SYNC_CONFLICT_STREAK_WARN_THRESHOLD = 3;
+
+// ============================================
 // API通信
 // ============================================
 /** APIリクエストデフォルトタイムアウト（ミリ秒） */

--- a/js/sync.js
+++ b/js/sync.js
@@ -38,10 +38,11 @@ const SYNC_LOG_KEYS = Object.freeze({
 });
 
 const DEFAULT_SYNC_LOG_SETTINGS = Object.freeze({
-  skipWarnThreshold: 3
+  skipWarnThreshold: DEFAULT_SYNC_CONFLICT_STREAK_WARN_THRESHOLD
 });
 
 let syncSkipStreak = 0;
+let syncConflictStreak = 0;
 
 function getSyncLogSettings() {
   const fromConfig = (typeof CONFIG !== 'undefined' && CONFIG && typeof CONFIG.syncLog === 'object')
@@ -52,6 +53,27 @@ function getSyncLogSettings() {
     skipWarnThreshold: Number.isFinite(threshold) && threshold > 0
       ? threshold
       : DEFAULT_SYNC_LOG_SETTINGS.skipWarnThreshold
+  };
+}
+
+function getSyncSelfHealSettings() {
+  const fromConfig = (typeof CONFIG !== 'undefined' && CONFIG && typeof CONFIG.syncSelfHeal === 'object')
+    ? CONFIG.syncSelfHeal
+    : null;
+  const revRescueWindowMs = Number(fromConfig?.revRescueWindowMs);
+  const cacheTtlMs = Number(fromConfig?.cacheTtlMs);
+  const conflictStreakWarnThreshold = Number(fromConfig?.conflictStreakWarnThreshold);
+
+  return {
+    revRescueWindowMs: Number.isFinite(revRescueWindowMs) && revRescueWindowMs > 0
+      ? revRescueWindowMs
+      : DEFAULT_SYNC_REV_RESCUE_WINDOW_MS,
+    cacheTtlMs: Number.isFinite(cacheTtlMs) && cacheTtlMs > 0
+      ? cacheTtlMs
+      : DEFAULT_SYNC_CACHE_TTL_MS,
+    conflictStreakWarnThreshold: Number.isFinite(conflictStreakWarnThreshold) && conflictStreakWarnThreshold > 0
+      ? conflictStreakWarnThreshold
+      : DEFAULT_SYNC_CONFLICT_STREAK_WARN_THRESHOLD
   };
 }
 
@@ -86,15 +108,73 @@ function logSyncDecision(input) {
   syncSkipStreak = 0;
 }
 
+function reportConflictStreak(memberId) {
+  const settings = getSyncSelfHealSettings();
+  syncConflictStreak += 1;
+  if (syncConflictStreak >= settings.conflictStreakWarnThreshold && (syncConflictStreak % settings.conflictStreakWarnThreshold) === 0) {
+    console.warn('[sync-conflict-streak]', {
+      conflictStreak: syncConflictStreak,
+      conflictStreakWarnThreshold: settings.conflictStreakWarnThreshold,
+      lastMemberId: String(memberId || '')
+    });
+  }
+}
+
+function resetConflictStreak() {
+  syncConflictStreak = 0;
+}
+
+function shouldApplyRemoteState(remoteRev, localRev, remoteServerUpdated, localServerUpdated) {
+  if (remoteRev > localRev) {
+    return true;
+  }
+
+  if (remoteRev !== localRev || remoteServerUpdated <= localServerUpdated) {
+    return false;
+  }
+
+  const settings = getSyncSelfHealSettings();
+  return (remoteServerUpdated - localServerUpdated) <= settings.revRescueWindowMs;
+}
+
 // Configからキーを取得（読み込み順序に依存するため安全策をとる）
-const STORAGE_KEY_CACHE = (typeof CONFIG !== 'undefined' && CONFIG.storageKeys) ? CONFIG.storageKeys.stateCache : 'whereabouts_state_cache';
-const STORAGE_KEY_SYNC = (typeof CONFIG !== 'undefined' && CONFIG.storageKeys) ? CONFIG.storageKeys.lastSync : 'whereabouts_last_sync';
+const STORAGE_KEY_CACHE = (typeof CONFIG !== 'undefined' && CONFIG.storageKeys) ? CONFIG.storageKeys.stateCache : STORAGE_KEY_CACHE_FALLBACK;
+const STORAGE_KEY_SYNC = (typeof CONFIG !== 'undefined' && CONFIG.storageKeys) ? CONFIG.storageKeys.lastSync : STORAGE_KEY_SYNC_FALLBACK;
+
+function serializeStateCachePayload(cache) {
+  return JSON.stringify({
+    savedAt: Date.now(),
+    state: cache
+  });
+}
+
+function restoreStateCache(rawCache) {
+  if (!rawCache) {
+    return;
+  }
+
+  const parsed = JSON.parse(rawCache);
+  const settings = getSyncSelfHealSettings();
+
+  if (parsed && typeof parsed === 'object' && parsed.state && typeof parsed.state === 'object') {
+    const savedAt = Number(parsed.savedAt || 0);
+    const isFresh = Number.isFinite(savedAt) && (Date.now() - savedAt) <= settings.cacheTtlMs;
+    if (isFresh) {
+      STATE_CACHE = parsed.state;
+      return;
+    }
+    localStorage.removeItem(STORAGE_KEY_CACHE);
+    return;
+  }
+
+  if (parsed && typeof parsed === 'object') {
+    STATE_CACHE = parsed;
+  }
+}
 
 try {
   const cached = localStorage.getItem(STORAGE_KEY_CACHE);
-  if (cached) {
-    STATE_CACHE = JSON.parse(cached);
-  }
+  restoreStateCache(cached);
   // ★追加: 最終同期時刻も復元する
   const cachedTs = localStorage.getItem(STORAGE_KEY_SYNC);
   if (cachedTs) {
@@ -446,6 +526,7 @@ async function pushRowDelta(key) {
     if (r.error === 'conflict') {
       const c = (r.conflicts && r.conflicts.find(x => x.id === key)) || null;
       if (c && c.server) {
+        reportConflictStreak(key);
         logSyncDecision({
           memberId: key,
           remoteRev: Number(c.server.rev || 0),
@@ -474,11 +555,12 @@ async function pushRowDelta(key) {
       if (!STATE_CACHE[key]) STATE_CACHE[key] = {};
       Object.assign(STATE_CACHE[key], st);
       try {
-        localStorage.setItem(STORAGE_KEY_CACHE, JSON.stringify(STATE_CACHE));
+        localStorage.setItem(STORAGE_KEY_CACHE, serializeStateCachePayload(STATE_CACHE));
       } catch (e) {
         console.error("Failed to update local cache:", e);
       }
 
+      resetConflictStreak();
       saveLocal();
       return;
     }
@@ -504,7 +586,7 @@ function applyState(data) {
 
   // ★修正: 最新状態をlocalStorageに保存（サーバーからの受信時）
   try {
-    localStorage.setItem(STORAGE_KEY_CACHE, JSON.stringify(STATE_CACHE));
+    localStorage.setItem(STORAGE_KEY_CACHE, serializeStateCachePayload(STATE_CACHE));
   } catch (e) {
     // quota exceededなどは無視
   }
@@ -544,7 +626,8 @@ function applyState(data) {
     const localRev = Number(tr?.dataset.rev || 0);
     const remoteServerUpdated = Number(v.serverUpdated || 0);
     const localServerUpdated = Number(tr?.dataset.serverUpdated || 0);
-    const decision = (tr && remoteRev > localRev) ? SYNC_DECISION.APPLY : SYNC_DECISION.SKIP;
+    const shouldApply = Boolean(tr) && shouldApplyRemoteState(remoteRev, localRev, remoteServerUpdated, localServerUpdated);
+    const decision = shouldApply ? SYNC_DECISION.APPLY : SYNC_DECISION.SKIP;
     logSyncDecision({
       memberId: k,
       remoteRev,
@@ -553,7 +636,7 @@ function applyState(data) {
       localServerUpdated,
       decision
     });
-    if (tr && remoteRev > localRev) { tr.dataset.rev = String(remoteRev); tr.dataset.serverUpdated = String(v.serverUpdated || 0); }
+    if (tr && shouldApply) { tr.dataset.rev = String(remoteRev); tr.dataset.serverUpdated = String(v.serverUpdated || 0); }
 
     ensureTimePrompt(tr);
   });


### PR DESCRIPTION
### Motivation
- 同期の自己修復ロジックで使われるマジックナンバーを排除し、運用時の変更窓口を一本化して誤調整や漏れを防止するため。 
- `sync.js` 側は定数/設定のみ参照する設計（DRY / SSOT）に合わせるため。

### Description
- `js/constants/timing.js` に同期自己修復の既定値を追加し、`DEFAULT_SYNC_REV_RESCUE_WINDOW_MS`、`DEFAULT_SYNC_CACHE_TTL_MS`、`DEFAULT_SYNC_CONFLICT_STREAK_WARN_THRESHOLD` を定義しました。 
- `js/config.js` に `syncSelfHeal` の上書き設定を追加し、運用意図を説明するコメントで変更窓口を明記しました（`syncSelfHeal.revRescueWindowMs` / `syncSelfHeal.cacheTtlMs` / `syncSelfHeal.conflictStreakWarnThreshold`）。 
- `js/sync.js` を修正して数値リテラルを排除し、`getSyncSelfHealSettings()` を導入して `CONFIG.syncSelfHeal` と既定値を統一参照するようにしました。 
- `js/sync.js` に自己修復ロジックを追加し、rev 同値時の `serverUpdated` 差分で追随を許可する `shouldApplyRemoteState()`、キャッシュを `{ savedAt, state }` 形式で保存/復元する `serializeStateCachePayload()`/`restoreStateCache()`（TTL判定付き）、および競合連続検知の報告 (`reportConflictStreak()`/`resetConflictStreak()`) を実装しました。 
- ストレージキーのフォールバックは `js/constants/storage.js` 側の定数を参照するよう統一し、`js/constants/storage.js` に自己修復用エンベロープ保存利用の注記を追記しました。 
- 運用ドキュメント `SSOT_GUIDE.md` に「同期自己修復パラメータ一覧（変更窓口）」を追記して、`timing.js`（既定値）と `config.js`（上書き）を変更窓口として明文化しました。 

### Testing
- `node --check js/sync.js`, `node --check js/config.js`, `node --check js/constants/timing.js`, `node --check js/constants/storage.js` を実行して構文チェックを行い、いずれもエラーなしで終了しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b5d6e0d8832792f9104f7bf03845)