### PR TITLE
sync: 同一行競合多発時の自動行リセット（自己修復）を追加

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -39,6 +39,13 @@ const CONFIG = {
     syncLog: {
         skipWarnThreshold: 3
     },
+    // 行単位の競合多発時に自動リセットする復旧パラメータ。
+    syncRecovery: {
+        // 同一行で一定時間内にこの回数を超えて競合したらリセット。
+        conflictThreshold: 3,
+        // 競合回数を集計する時間窓。
+        windowMs: 180000
+    },
     publicOfficeFallbacks: [],
     printSettings: {
         cellWidth: '30px',
@@ -49,7 +56,8 @@ const CONFIG = {
     /* === ストレージキー設定 (SSOT) === */
     storageKeys: {
         stateCache: 'whereabouts_state_cache',
-        lastSync: 'whereabouts_last_sync'
+        lastSync: 'whereabouts_last_sync',
+        conflictRecovery: 'whereabouts_conflict_recovery'
     },
     /* === カラーパレット設定 (SSOT) === */
     colorPalette: [

--- a/js/constants/storage.js
+++ b/js/constants/storage.js
@@ -48,6 +48,12 @@ const STORAGE_KEY_CACHE_FALLBACK = 'whereabouts_state_cache';
  */
 const STORAGE_KEY_SYNC_FALLBACK = 'whereabouts_last_sync';
 
+/**
+ * 行単位競合回復状態キー（CONFIG.storageKeysから参照）
+ * @deprecated CONFIG.storageKeys.conflictRecovery を使用すること
+ */
+const STORAGE_KEY_CONFLICT_RECOVERY_FALLBACK = 'whereabouts_conflict_recovery';
+
 // ============================================
 // イベント選択状態キー生成
 // ============================================

--- a/js/constants/timing.js
+++ b/js/constants/timing.js
@@ -49,6 +49,18 @@ const DEFAULT_SYNC_CACHE_TTL_MS = 21600000;
  */
 const DEFAULT_SYNC_CONFLICT_STREAK_WARN_THRESHOLD = 3;
 
+/**
+ * 行単位リセット発動しきい値（回）- CONFIG.syncRecovery.conflictThreshold で上書き可
+ * 同一行でこの回数を超えて競合した場合に自動修復（行リセット）を行う。
+ */
+const DEFAULT_SYNC_RECOVERY_CONFLICT_THRESHOLD = 3;
+
+/**
+ * 行単位リセット判定ウィンドウ（ミリ秒）- CONFIG.syncRecovery.windowMs で上書き可
+ * 直近 windowMs 内の競合回数で自動修復の発動可否を判定する。
+ */
+const DEFAULT_SYNC_RECOVERY_WINDOW_MS = 180000;
+
 // ============================================
 // API通信
 // ============================================

--- a/js/sync.js
+++ b/js/sync.js
@@ -21,6 +21,7 @@ let lastPollTime = 0;
 // ★修正: STATE_CACHE と lastSyncTimestamp を localStorage から初期化
 let STATE_CACHE = {};
 let lastSyncTimestamp = 0;
+let conflictRecoveryState = {};
 
 const SYNC_DECISION = Object.freeze({
   APPLY: 'apply',
@@ -74,6 +75,23 @@ function getSyncSelfHealSettings() {
     conflictStreakWarnThreshold: Number.isFinite(conflictStreakWarnThreshold) && conflictStreakWarnThreshold > 0
       ? conflictStreakWarnThreshold
       : DEFAULT_SYNC_CONFLICT_STREAK_WARN_THRESHOLD
+  };
+}
+
+function getSyncRecoverySettings() {
+  const fromConfig = (typeof CONFIG !== 'undefined' && CONFIG && typeof CONFIG.syncRecovery === 'object')
+    ? CONFIG.syncRecovery
+    : null;
+  const conflictThreshold = Number(fromConfig?.conflictThreshold);
+  const windowMs = Number(fromConfig?.windowMs);
+
+  return {
+    conflictThreshold: Number.isFinite(conflictThreshold) && conflictThreshold > 0
+      ? conflictThreshold
+      : DEFAULT_SYNC_RECOVERY_CONFLICT_THRESHOLD,
+    windowMs: Number.isFinite(windowMs) && windowMs > 0
+      ? windowMs
+      : DEFAULT_SYNC_RECOVERY_WINDOW_MS
   };
 }
 
@@ -140,6 +158,9 @@ function shouldApplyRemoteState(remoteRev, localRev, remoteServerUpdated, localS
 // Configからキーを取得（読み込み順序に依存するため安全策をとる）
 const STORAGE_KEY_CACHE = (typeof CONFIG !== 'undefined' && CONFIG.storageKeys) ? CONFIG.storageKeys.stateCache : STORAGE_KEY_CACHE_FALLBACK;
 const STORAGE_KEY_SYNC = (typeof CONFIG !== 'undefined' && CONFIG.storageKeys) ? CONFIG.storageKeys.lastSync : STORAGE_KEY_SYNC_FALLBACK;
+const STORAGE_KEY_CONFLICT_RECOVERY = (typeof CONFIG !== 'undefined' && CONFIG.storageKeys && typeof CONFIG.storageKeys.conflictRecovery === 'string' && CONFIG.storageKeys.conflictRecovery)
+  ? CONFIG.storageKeys.conflictRecovery
+  : STORAGE_KEY_CONFLICT_RECOVERY_FALLBACK;
 
 function serializeStateCachePayload(cache) {
   return JSON.stringify({
@@ -172,6 +193,90 @@ function restoreStateCache(rawCache) {
   }
 }
 
+function normalizeConflictRecoveryState(rawState) {
+  if (!rawState || typeof rawState !== 'object') {
+    return {};
+  }
+
+  const normalized = {};
+  Object.entries(rawState).forEach(([memberId, value]) => {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+    const count = Number(value.count || 0);
+    const lastConflictAt = Number(value.lastConflictAt || 0);
+    if (count > 0 || lastConflictAt > 0) {
+      normalized[String(memberId)] = {
+        count: count > 0 ? count : 0,
+        lastConflictAt: lastConflictAt > 0 ? lastConflictAt : 0
+      };
+    }
+  });
+
+  return normalized;
+}
+
+function saveConflictRecoveryState() {
+  try {
+    localStorage.setItem(STORAGE_KEY_CONFLICT_RECOVERY, JSON.stringify(conflictRecoveryState));
+  } catch (e) {
+    console.error('Failed to persist conflict recovery state:', e);
+  }
+}
+
+function clearConflictRecoveryState(memberId) {
+  if (!memberId) {
+    return;
+  }
+  const key = String(memberId);
+  if (conflictRecoveryState[key]) {
+    delete conflictRecoveryState[key];
+    saveConflictRecoveryState();
+  }
+}
+
+function trackConflictAndShouldReset(memberId, nowTs = Date.now()) {
+  const key = String(memberId || '');
+  if (!key) {
+    return false;
+  }
+
+  const settings = getSyncRecoverySettings();
+  const prev = conflictRecoveryState[key] || { count: 0, lastConflictAt: 0 };
+  const withinWindow = prev.lastConflictAt > 0 && (nowTs - prev.lastConflictAt) <= settings.windowMs;
+  const nextCount = withinWindow ? (prev.count + 1) : 1;
+
+  conflictRecoveryState[key] = {
+    count: nextCount,
+    lastConflictAt: nowTs
+  };
+  saveConflictRecoveryState();
+
+  return nextCount > settings.conflictThreshold;
+}
+
+function applyRowConflictReset(memberId) {
+  const key = String(memberId || '');
+  if (!key) {
+    return;
+  }
+
+  const tr = document.getElementById(`row-${key}`);
+  if (tr && tr.dataset) {
+    delete tr.dataset.rev;
+    delete tr.dataset.serverUpdated;
+  }
+  if (Object.prototype.hasOwnProperty.call(STATE_CACHE, key)) {
+    delete STATE_CACHE[key];
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY_CACHE, serializeStateCachePayload(STATE_CACHE));
+  } catch (e) {
+    console.error('Failed to persist state cache after conflict reset:', e);
+  }
+  clearConflictRecoveryState(key);
+}
+
 try {
   const cached = localStorage.getItem(STORAGE_KEY_CACHE);
   restoreStateCache(cached);
@@ -182,6 +287,11 @@ try {
     if (Number.isFinite(ts)) {
       lastSyncTimestamp = ts;
     }
+  }
+
+  const rawConflictRecovery = localStorage.getItem(STORAGE_KEY_CONFLICT_RECOVERY);
+  if (rawConflictRecovery) {
+    conflictRecoveryState = normalizeConflictRecoveryState(JSON.parse(rawConflictRecovery));
   }
 } catch (e) {
   console.error("Local cache restore failed:", e);
@@ -527,6 +637,7 @@ async function pushRowDelta(key) {
       const c = (r.conflicts && r.conflicts.find(x => x.id === key)) || null;
       if (c && c.server) {
         reportConflictStreak(key);
+        const shouldResetRow = trackConflictAndShouldReset(key);
         logSyncDecision({
           memberId: key,
           remoteRev: Number(c.server.rev || 0),
@@ -535,8 +646,14 @@ async function pushRowDelta(key) {
           localServerUpdated: Number(tr?.dataset.serverUpdated || 0),
           decision: SYNC_DECISION.HEAL
         });
-        applyState({ [key]: c.server });
-        toast('他端末と競合しました（サーバ値で更新）', false);
+
+        if (shouldResetRow) {
+          applyRowConflictReset(key);
+          toast('同一行で競合が続いたため自動修復を実施しました。次回同期で最新値を再取得します。', false);
+        } else {
+          applyState({ [key]: c.server });
+          toast('他端末と競合しました（サーバ値で更新）', false);
+        }
       } else {
         const rev = Number((r.rev && r.rev[key]) || 0);
         const ts = Number((r.serverUpdated && r.serverUpdated[key]) || 0);
@@ -561,6 +678,7 @@ async function pushRowDelta(key) {
       }
 
       resetConflictStreak();
+      clearConflictRecoveryState(key);
       saveLocal();
       return;
     }


### PR DESCRIPTION
### Motivation
- 同一行で競合が短時間に多発した際に手動リロードやユーザー介入が必要になる事象を軽減するため、行単位で自動的にリセットして次回pollでサーバー値を再取得する自己修復を導入する。 

### Description
- `CONFIG.syncRecovery` セクションを追加して `conflictThreshold` と `windowMs` を設定から制御可能にし、`storageKeys.conflictRecovery` も追加してキーのハードコーディングを排除した。 
- `js/constants/timing.js` に `DEFAULT_SYNC_RECOVERY_CONFLICT_THRESHOLD` と `DEFAULT_SYNC_RECOVERY_WINDOW_MS` を追加して SSOT 化した。 
- `js/sync.js` に行単位の競合履歴メモリ `conflictRecoveryState` と `localStorage` 永続化／復元処理を追加し、`getSyncRecoverySettings()`、`trackConflictAndShouldReset()`、`applyRowConflictReset()`、`clearConflictRecoveryState()`、`normalizeConflictRecoveryState()`、`saveConflictRecoveryState()` を実装した。 
- `pushRowDelta(key)` の conflict 分岐でトラッキングし、同一行の競合回数が設定閾値を超えた場合に `tr.dataset.rev` / `tr.dataset.serverUpdated` をクリアし `STATE_CACHE[key]` を削除して「自動修復を実施した」旨のトーストを表示するようにした。 
- 正常保存時には当該行の競合回復状態をクリアするようにして不要な履歴を消去するようにした。 

### Testing
- `node --check js/sync.js && node --check js/config.js && node --check js/constants/timing.js && node --check js/constants/storage.js` を実行しエラー無く成功した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b73def38832780f12b3e73738519)