### PR TITLE
sync: localStorage復元時に state cache 検証と乖離での全体パージを追加

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -46,6 +46,15 @@ const CONFIG = {
         // 競合回数を集計する時間窓。
         windowMs: 180000
     },
+    // localStorage 復元時の state cache 検証パラメータ。
+    syncCacheValidation: {
+        // rev の許容上限（0以上、整数）。
+        maxRev: 2147483647,
+        // serverUpdated が現在時刻より先でも許容する最大ズレ。
+        maxServerUpdatedAheadMs: 300000,
+        // lastSyncTimestamp との乖離がこの閾値を超える場合は全体パージ。
+        purgeDriftThresholdMs: 86400000
+    },
     publicOfficeFallbacks: [],
     printSettings: {
         cellWidth: '30px',

--- a/js/constants/timing.js
+++ b/js/constants/timing.js
@@ -61,6 +61,25 @@ const DEFAULT_SYNC_RECOVERY_CONFLICT_THRESHOLD = 3;
  */
 const DEFAULT_SYNC_RECOVERY_WINDOW_MS = 180000;
 
+/**
+ * state cache 内の rev の上限値 - CONFIG.syncCacheValidation.maxRev で上書き可
+ * 不正な巨大値混入による比較異常を防ぐ。
+ */
+const DEFAULT_SYNC_CACHE_MAX_REV = 2147483647;
+
+/**
+ * state cache 内の serverUpdated の許容未来ズレ（ミリ秒）
+ * - CONFIG.syncCacheValidation.maxServerUpdatedAheadMs で上書き可
+ */
+const DEFAULT_SYNC_CACHE_MAX_SERVER_UPDATED_AHEAD_MS = 300000;
+
+/**
+ * lastSyncTimestamp と各行 serverUpdated の最大乖離（ミリ秒）
+ * - CONFIG.syncCacheValidation.purgeDriftThresholdMs で上書き可
+ * この閾値を超える行があれば cache 全体をパージする。
+ */
+const DEFAULT_SYNC_CACHE_PURGE_DRIFT_THRESHOLD_MS = 86400000;
+
 // ============================================
 // API通信
 // ============================================

--- a/js/sync.js
+++ b/js/sync.js
@@ -95,6 +95,27 @@ function getSyncRecoverySettings() {
   };
 }
 
+function getSyncCacheValidationSettings() {
+  const fromConfig = (typeof CONFIG !== 'undefined' && CONFIG && typeof CONFIG.syncCacheValidation === 'object')
+    ? CONFIG.syncCacheValidation
+    : null;
+  const maxRev = Number(fromConfig?.maxRev);
+  const maxServerUpdatedAheadMs = Number(fromConfig?.maxServerUpdatedAheadMs);
+  const purgeDriftThresholdMs = Number(fromConfig?.purgeDriftThresholdMs);
+
+  return {
+    maxRev: Number.isInteger(maxRev) && maxRev > 0
+      ? maxRev
+      : DEFAULT_SYNC_CACHE_MAX_REV,
+    maxServerUpdatedAheadMs: Number.isFinite(maxServerUpdatedAheadMs) && maxServerUpdatedAheadMs >= 0
+      ? maxServerUpdatedAheadMs
+      : DEFAULT_SYNC_CACHE_MAX_SERVER_UPDATED_AHEAD_MS,
+    purgeDriftThresholdMs: Number.isFinite(purgeDriftThresholdMs) && purgeDriftThresholdMs > 0
+      ? purgeDriftThresholdMs
+      : DEFAULT_SYNC_CACHE_PURGE_DRIFT_THRESHOLD_MS
+  };
+}
+
 function logSyncDecision(input) {
   const payload = input && typeof input === 'object' ? input : {};
   const settings = getSyncLogSettings();
@@ -193,6 +214,70 @@ function restoreStateCache(rawCache) {
   }
 }
 
+function purgeSyncLocalCache(reason, details = {}) {
+  STATE_CACHE = {};
+  lastSyncTimestamp = 0;
+  localStorage.removeItem(STORAGE_KEY_CACHE);
+  localStorage.removeItem(STORAGE_KEY_SYNC);
+  console.warn('[sync-cache-restore]', {
+    fullPurge: true,
+    reason: String(reason || 'unspecified'),
+    removedRows: Number(details.removedRows || 0),
+    ...details
+  });
+}
+
+function sanitizeStateCache(cache, lastSyncTs) {
+  if (!cache || typeof cache !== 'object') {
+    return {
+      sanitizedCache: {},
+      removedRows: 0,
+      fullPurge: false
+    };
+  }
+
+  const settings = getSyncCacheValidationSettings();
+  const now = Date.now();
+  const sanitizedCache = {};
+  let removedRows = 0;
+  let hasDriftOverflow = false;
+
+  Object.entries(cache).forEach(([memberId, row]) => {
+    if (!row || typeof row !== 'object') {
+      removedRows += 1;
+      return;
+    }
+
+    const rev = Number(row.rev);
+    const serverUpdated = Number(row.serverUpdated);
+    const isRevValid = Number.isInteger(rev) && rev >= 0 && rev <= settings.maxRev;
+    const isServerUpdatedValid = Number.isFinite(serverUpdated)
+      && serverUpdated >= 0
+      && serverUpdated <= (now + settings.maxServerUpdatedAheadMs);
+
+    if (!isRevValid || !isServerUpdatedValid) {
+      removedRows += 1;
+      return;
+    }
+
+    if (Number.isFinite(lastSyncTs) && lastSyncTs > 0) {
+      const drift = Math.abs(serverUpdated - lastSyncTs);
+      if (drift > settings.purgeDriftThresholdMs) {
+        hasDriftOverflow = true;
+      }
+    }
+
+    sanitizedCache[String(memberId)] = row;
+  });
+
+  return {
+    sanitizedCache,
+    removedRows,
+    fullPurge: hasDriftOverflow,
+    driftThresholdMs: settings.purgeDriftThresholdMs
+  };
+}
+
 function normalizeConflictRecoveryState(rawState) {
   if (!rawState || typeof rawState !== 'object') {
     return {};
@@ -287,6 +372,23 @@ try {
     if (Number.isFinite(ts)) {
       lastSyncTimestamp = ts;
     }
+  }
+
+  const validation = sanitizeStateCache(STATE_CACHE, lastSyncTimestamp);
+  if (validation.fullPurge) {
+    purgeSyncLocalCache('drift-over-threshold', {
+      removedRows: validation.removedRows,
+      driftThresholdMs: validation.driftThresholdMs
+    });
+  } else {
+    STATE_CACHE = validation.sanitizedCache;
+    if (validation.removedRows > 0) {
+      localStorage.setItem(STORAGE_KEY_CACHE, serializeStateCachePayload(STATE_CACHE));
+    }
+    console.info('[sync-cache-restore]', {
+      fullPurge: false,
+      removedRows: validation.removedRows
+    });
   }
 
   const rawConflictRecovery = localStorage.getItem(STORAGE_KEY_CONFLICT_RECOVERY);


### PR DESCRIPTION
### Motivation

- localStorage から復元した `STATE_CACHE` が不正な値や時刻ズレにより同期ロジックを破壊するのを防ぐため、復元直後に検証を行い安全に扱える状態に整える必要がありました。
- 行単位での不正値除去と、`lastSyncTimestamp` と行の `serverUpdated` の大きな乖離を検出した場合は部分的な修正ではなくキャッシュ全体を安全にパージして不整合を回避する意図です。
- 閾値は SSOT として `js/constants/timing.js` / `js/config.js` に置き、運用で上書き可能にします。

### Description

- `js/constants/timing.js` にデフォルト設定を追加して、`DEFAULT_SYNC_CACHE_MAX_REV`、`DEFAULT_SYNC_CACHE_MAX_SERVER_UPDATED_AHEAD_MS`、`DEFAULT_SYNC_CACHE_PURGE_DRIFT_THRESHOLD_MS` を導入しました。
- `js/config.js` に `CONFIG.syncCacheValidation` を追加し、運用で `maxRev` / `maxServerUpdatedAheadMs` / `purgeDriftThresholdMs` を上書きできるようにしました。
- `js/sync.js` に `getSyncCacheValidationSettings()`、`sanitizeStateCache(cache, lastSyncTs)`、`purgeSyncLocalCache(reason, details)` を追加し、`STATE_CACHE` 復元直後に各行の `rev` と `serverUpdated` を型・範囲チェックして不正行を除去し、乖離が閾値を超える場合は `stateCache` と `lastSync` を同時に削除する全体パージを行うようにしました。
- 復元ログに必ず `removedRows`（除去した行数）と `fullPurge`（全体パージか否か）を出力するようにし、部分削除による再不整合を防止しました。

### Testing

- `node --check js/sync.js` が成功しました。
- `node --check js/config.js` が成功しました。
- `node --check js/constants/timing.js` が成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b98146848327b26a94c27f3a847a)