### PR TITLE
sync: rev不整合救済判定と異常rev修復を追加

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -31,6 +31,8 @@ const CONFIG = {
     syncSelfHeal: {
         // rev が同値でも serverUpdated の進みを許容する救済ウィンドウ。
         revRescueWindowMs: 180000,
+        // rev 不整合(remoteRev <= localRev)時に serverUpdated 差分で救済する閾値。
+        revSkewHealWindowMs: 180000,
         // 復元対象とみなす同期キャッシュの寿命。期限超過時は破棄して再同期。
         cacheTtlMs: 21600000,
         // 競合が連続した場合の警告しきい値。運用で多発監視する。

--- a/js/constants/timing.js
+++ b/js/constants/timing.js
@@ -38,6 +38,12 @@ const DEFAULT_TOKEN_TTL_MS = 3600000;
 const DEFAULT_SYNC_REV_RESCUE_WINDOW_MS = 180000;
 
 /**
+ * rev不整合時の救済判定ウィンドウ（ミリ秒）- CONFIG.syncSelfHeal.revSkewHealWindowMs で上書き可
+ * remoteRev <= localRev でも serverUpdated がこの閾値以上進んでいれば救済適用する。
+ */
+const DEFAULT_SYNC_REV_SKEW_HEAL_WINDOW_MS = 180000;
+
+/**
  * 同期キャッシュ寿命（ミリ秒）- CONFIG.syncSelfHeal.cacheTtlMs で上書き可
  * 期限切れキャッシュは復元せず、破損時の自己修復を優先する。
  */

--- a/js/sync.js
+++ b/js/sync.js
@@ -62,6 +62,7 @@ function getSyncSelfHealSettings() {
     ? CONFIG.syncSelfHeal
     : null;
   const revRescueWindowMs = Number(fromConfig?.revRescueWindowMs);
+  const revSkewHealWindowMs = Number(fromConfig?.revSkewHealWindowMs);
   const cacheTtlMs = Number(fromConfig?.cacheTtlMs);
   const conflictStreakWarnThreshold = Number(fromConfig?.conflictStreakWarnThreshold);
 
@@ -69,6 +70,9 @@ function getSyncSelfHealSettings() {
     revRescueWindowMs: Number.isFinite(revRescueWindowMs) && revRescueWindowMs > 0
       ? revRescueWindowMs
       : DEFAULT_SYNC_REV_RESCUE_WINDOW_MS,
+    revSkewHealWindowMs: Number.isFinite(revSkewHealWindowMs) && revSkewHealWindowMs > 0
+      ? revSkewHealWindowMs
+      : DEFAULT_SYNC_REV_SKEW_HEAL_WINDOW_MS,
     cacheTtlMs: Number.isFinite(cacheTtlMs) && cacheTtlMs > 0
       ? cacheTtlMs
       : DEFAULT_SYNC_CACHE_TTL_MS,
@@ -163,17 +167,44 @@ function resetConflictStreak() {
   syncConflictStreak = 0;
 }
 
-function shouldApplyRemoteState(remoteRev, localRev, remoteServerUpdated, localServerUpdated) {
-  if (remoteRev > localRev) {
-    return true;
-  }
+const SYNC_HEAL_REASON = Object.freeze({
+  NONE: 'none',
+  NORMAL: 'normal',
+  HEAL: 'heal',
+  REPAIR: 'repair'
+});
 
-  if (remoteRev !== localRev || remoteServerUpdated <= localServerUpdated) {
-    return false;
-  }
-
+function evaluateRemoteStateDecision(remoteRev, localRev, remoteServerUpdated, localServerUpdated) {
   const settings = getSyncSelfHealSettings();
-  return (remoteServerUpdated - localServerUpdated) <= settings.revRescueWindowMs;
+  const cacheValidation = getSyncCacheValidationSettings();
+  const hasInvalidLocalRev = !Number.isFinite(localRev) || localRev < 0 || localRev > cacheValidation.maxRev;
+
+  if (hasInvalidLocalRev) {
+    return {
+      shouldApply: true,
+      reason: SYNC_HEAL_REASON.REPAIR
+    };
+  }
+
+  if (remoteRev > localRev) {
+    return {
+      shouldApply: true,
+      reason: SYNC_HEAL_REASON.NORMAL
+    };
+  }
+
+  const skewMs = remoteServerUpdated - localServerUpdated;
+  if (remoteRev <= localRev && skewMs > settings.revSkewHealWindowMs) {
+    return {
+      shouldApply: true,
+      reason: SYNC_HEAL_REASON.HEAL
+    };
+  }
+
+  return {
+    shouldApply: false,
+    reason: SYNC_HEAL_REASON.NONE
+  };
 }
 
 // Configからキーを取得（読み込み順序に依存するため安全策をとる）
@@ -801,25 +832,17 @@ async function pushRowDelta(key) {
 function applyState(data) {
   if (!data) return;
 
-  // キャッシュにマージ
-  Object.assign(STATE_CACHE, data);
-
-  // ★修正: 最新状態をlocalStorageに保存（サーバーからの受信時）
-  try {
-    localStorage.setItem(STORAGE_KEY_CACHE, serializeStateCachePayload(STATE_CACHE));
-  } catch (e) {
-    // quota exceededなどは無視
-  }
+  let hasStateCacheUpdates = false;
 
   Object.entries(data).forEach(([k, v]) => {
     if (PENDING_ROWS.has(k)) {
       const trPending = document.getElementById(`row-${k}`);
       logSyncDecision({
         memberId: k,
-        remoteRev: Number(v?.rev || 0),
-        localRev: Number(trPending?.dataset.rev || 0),
-        remoteServerUpdated: Number(v?.serverUpdated || 0),
-        localServerUpdated: Number(trPending?.dataset.serverUpdated || 0),
+        remoteRev: Number(v?.rev),
+        localRev: Number(trPending?.dataset.rev),
+        remoteServerUpdated: Number(v?.serverUpdated),
+        localServerUpdated: Number(trPending?.dataset.serverUpdated),
         decision: SYNC_DECISION.SKIP
       });
       return;
@@ -842,12 +865,14 @@ function applyState(data) {
     setIfNeeded(t, v.time || ""); setIfNeeded(p, v.tomorrowPlan || ""); setIfNeeded(n, v.note || "");
     if (s && t) toggleTimeEnable(s, t);
 
-    const remoteRev = Number(v.rev || 0);
-    const localRev = Number(tr?.dataset.rev || 0);
-    const remoteServerUpdated = Number(v.serverUpdated || 0);
-    const localServerUpdated = Number(tr?.dataset.serverUpdated || 0);
-    const shouldApply = Boolean(tr) && shouldApplyRemoteState(remoteRev, localRev, remoteServerUpdated, localServerUpdated);
-    const decision = shouldApply ? SYNC_DECISION.APPLY : SYNC_DECISION.SKIP;
+    const remoteRev = Number(v?.rev);
+    const localRev = Number(tr?.dataset.rev);
+    const remoteServerUpdated = Number(v?.serverUpdated);
+    const localServerUpdated = Number(tr?.dataset.serverUpdated);
+    const decisionResult = Boolean(tr)
+      ? evaluateRemoteStateDecision(remoteRev, localRev, remoteServerUpdated, localServerUpdated)
+      : { shouldApply: false, reason: SYNC_HEAL_REASON.NONE };
+    const decision = decisionResult.shouldApply ? SYNC_DECISION.APPLY : SYNC_DECISION.SKIP;
     logSyncDecision({
       memberId: k,
       remoteRev,
@@ -856,10 +881,45 @@ function applyState(data) {
       localServerUpdated,
       decision
     });
-    if (tr && shouldApply) { tr.dataset.rev = String(remoteRev); tr.dataset.serverUpdated = String(v.serverUpdated || 0); }
+
+    if (tr && decisionResult.shouldApply) {
+      const nextRev = Number.isFinite(remoteRev) ? remoteRev : 0;
+      const nextServerUpdated = Number.isFinite(remoteServerUpdated) ? remoteServerUpdated : 0;
+      tr.dataset.rev = String(nextRev);
+      tr.dataset.serverUpdated = String(nextServerUpdated);
+
+      if (!STATE_CACHE[k] || typeof STATE_CACHE[k] !== 'object') {
+        STATE_CACHE[k] = {};
+      }
+      Object.assign(STATE_CACHE[k], v, {
+        rev: nextRev,
+        serverUpdated: nextServerUpdated
+      });
+      hasStateCacheUpdates = true;
+
+      if (decisionResult.reason !== SYNC_HEAL_REASON.NONE) {
+        console.info('[sync-heal]', {
+          memberId: k,
+          reason: decisionResult.reason,
+          remoteRev: nextRev,
+          localRev,
+          remoteServerUpdated: nextServerUpdated,
+          localServerUpdated
+        });
+      }
+    }
 
     ensureTimePrompt(tr);
   });
+
+  if (hasStateCacheUpdates) {
+    try {
+      localStorage.setItem(STORAGE_KEY_CACHE, serializeStateCachePayload(STATE_CACHE));
+    } catch (e) {
+      // quota exceededなどは無視
+    }
+  }
+
   recolor();
   updateStatusFilterCounts();
   applyFilters();


### PR DESCRIPTION
### Motivation
- サーバーとローカルの `rev` がずれた場合に誤ったスキップや不整合を起こす事象を防ぐため、救済判定を導入して運用調査しやすくする。
- `applyState` の判定周りを数値化して一貫化し、上書き時に UI のデータ属性とキャッシュの不整合が起きないようにする。

### Description
- `js/constants/timing.js` に既定値 `DEFAULT_SYNC_REV_SKEW_HEAL_WINDOW_MS` を追加し、`rev` 不整合（remoteRev <= localRev）時の救済判定ウィンドウを定義した。
- `js/config.js` の `syncSelfHeal` に `revSkewHealWindowMs` を追加して設定から閾値を上書き可能にした。
- 判定ロジックを `shouldApplyRemoteState` から `evaluateRemoteStateDecision` に分離し、`normal`（`remoteRev > localRev`）、`heal`（`remoteRev <= localRev` だが `serverUpdated` 差分が `revSkewHealWindowMs` を超える）、`repair`（`localRev` が非数/負数/上限超過の異常値）という3系統で判定するようにした（判定結果は `{ shouldApply, reason }` を返す）。
- `applyState` を修正して `remoteRev` / `localRev` / `remoteServerUpdated` / `localServerUpdated` を数値化して判定に使用し、適用時は必ず `tr.dataset.rev` と `tr.dataset.serverUpdated` を同時更新して `STATE_CACHE[k]` にも同一値を反映し、変更が発生した場合のみ `localStorage` を更新するようにした。
- 救済・修復が発生した行については理由を `console.info('[sync-heal]', ...)` で出力して現場調査を行いやすくした（識別子と `reason` は `normal` / `heal` / `repair`）。

### Testing
- 自動構文チェックとして `node --check js/sync.js` を実行し成功しました.
- 自動構文チェックとして `node --check js/config.js` を実行し成功しました.
- 自動構文チェックとして `node --check js/constants/timing.js` を実行し成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7bb2f94b483279007549aea5f2aa4)